### PR TITLE
Refactor plugin registry as catalog

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,7 +17,7 @@ backend/
 ├── internal/
 │   ├── daemon/              # Reader → writer pipeline
 │   │   └── runner.go
-│   └── plugins/             # Plugin registry & factory
+│   └── plugins/             # Plugin catalog/registry
 │       └── registry.go
 ├── migrations/              # SQL migrations (run on startup)
 └── pkg/
@@ -48,11 +48,8 @@ Readers and writers are registered at startup via the plugin registry. Adding a 
 
 ```go
 type ReaderPlugin interface {
-    Name() string
-    Description() string
-    RequiredScopes() []string
-    NewReader(httpClient *http.Client, cfg *config.Config, rules []api.Rule,
-              labels api.Labels, stateManager *state.Manager, logger *slog.Logger) (api.Reader, error)
+    Metadata() ReaderMetadata
+    NewReader(input ReaderInput) (api.Reader, error)
 }
 ```
 
@@ -62,10 +59,8 @@ type ReaderPlugin interface {
 
 ```go
 type WriterPlugin interface {
-    Name() string
-    Description() string
-    RequiredScopes() []string
-    NewWriter(httpClient *http.Client, cfg *config.Config, logger *slog.Logger) (api.Writer, error)
+    Metadata() WriterMetadata
+    NewWriter(input WriterInput) (api.Writer, error)
 }
 ```
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -733,11 +733,12 @@ func registerPlugins(registry *plugins.Registry, fs embed.FS, logger *slog.Logge
 
 	for _, p := range []plugins.ReaderPlugin{gmailPlugin, tbPlugin} {
 		if err := registry.RegisterReader(p); err != nil {
-			return fmt.Errorf("registering reader %s: %w", p.Name(), err)
+			return fmt.Errorf("registering reader %s: %w", p.Metadata().Name, err)
 		}
 	}
-	if err := registry.RegisterWriter(&postgresplugin.Plugin{}); err != nil {
-		return fmt.Errorf("registering postgres writer: %w", err)
+	postgresPlugin := &postgresplugin.Plugin{}
+	if err := registry.RegisterWriter(postgresPlugin); err != nil {
+		return fmt.Errorf("registering writer %s: %w", postgresPlugin.Metadata().Name, err)
 	}
 	return nil
 }

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -539,12 +539,17 @@ func (h *Handlers) HandleListReaders(w http.ResponseWriter, _ *http.Request) {
 	rps := h.registry.ListReaders()
 	infos := make([]ReaderInfo, 0, len(rps))
 	for _, p := range rps {
+		meta := p.Metadata()
+		configSchema := meta.ConfigSchema
+		if configSchema == nil {
+			configSchema = []plugins.ConfigField{}
+		}
 		infos = append(infos, ReaderInfo{
-			Name:                      p.Name(),
-			Description:               p.Description(),
-			AuthType:                  p.AuthType(),
-			RequiresCredentialsUpload: p.RequiresCredentialsUpload(),
-			ConfigSchema:              p.ConfigSchema(),
+			Name:                      meta.Name,
+			Description:               meta.Description,
+			AuthType:                  meta.Auth.Type,
+			RequiresCredentialsUpload: meta.Auth.RequiresCredentialsUpload,
+			ConfigSchema:              configSchema,
 		})
 	}
 	writeJSON(w, http.StatusOK, infos)
@@ -555,9 +560,10 @@ func (h *Handlers) HandleListWriters(w http.ResponseWriter, _ *http.Request) {
 	wps := h.registry.ListWriters()
 	infos := make([]WriterInfo, 0, len(wps))
 	for _, p := range wps {
+		meta := p.Metadata()
 		infos = append(infos, WriterInfo{
-			Name:        p.Name(),
-			Description: p.Description(),
+			Name:        meta.Name,
+			Description: meta.Description,
 		})
 	}
 	writeJSON(w, http.StatusOK, infos)
@@ -574,7 +580,7 @@ func (h *Handlers) HandleUploadCredentials(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
 		return
 	}
-	if !plugin.RequiresCredentialsUpload() {
+	if !plugin.Metadata().Auth.RequiresCredentialsUpload {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("reader %q does not require credentials upload", name))
 		return
 	}
@@ -649,7 +655,7 @@ func (h *Handlers) HandleAuthStart(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
 		return
 	}
-	if plugin.AuthType() != plugins.AuthTypeOAuth {
+	if plugin.Metadata().Auth.Type != plugins.AuthTypeOAuth {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("reader %q does not use OAuth", name))
 		return
 	}
@@ -671,8 +677,9 @@ func (h *Handlers) HandleAuthStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	redirectURL := h.baseURL + "/api/auth/callback"
-	h.logger.Debug("building OAuth config", "reader", name, "redirect_url", redirectURL, "scopes", plugin.RequiredScopes())
-	oauthCfg, err := client.GetOAuthConfig(secretJSON, redirectURL, plugin.RequiredScopes()...)
+	scopes := plugin.Metadata().Auth.RequiredScopes
+	h.logger.Debug("building OAuth config", "reader", name, "redirect_url", redirectURL, "scopes", scopes)
+	oauthCfg, err := client.GetOAuthConfig(secretJSON, redirectURL, scopes...)
 	if err != nil {
 		h.logger.Error("failed to parse credentials", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to parse credentials: "+err.Error())
@@ -730,7 +737,7 @@ func (h *Handlers) exchangeAndSaveToken(name, code, redirectURL string) error {
 		return errCredentialsMissing
 	}
 
-	oauthCfg, err := client.GetOAuthConfig(secretJSON, redirectURL, plugin.RequiredScopes()...)
+	oauthCfg, err := client.GetOAuthConfig(secretJSON, redirectURL, plugin.Metadata().Auth.RequiredScopes...)
 	if err != nil {
 		return fmt.Errorf("failed to parse credentials: %w", err)
 	}
@@ -860,7 +867,7 @@ func (h *Handlers) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
 		return
 	}
-	if plugin.AuthType() != plugins.AuthTypeOAuth {
+	if plugin.Metadata().Auth.Type != plugins.AuthTypeOAuth {
 		// Config-only readers are always "authenticated" once configured.
 		writeJSON(w, http.StatusOK, map[string]any{"authenticated": true, "auth_type": plugins.AuthTypeConfig})
 		return
@@ -1030,9 +1037,10 @@ func (h *Handlers) HandleReaderStatus(w http.ResponseWriter, r *http.Request) {
 		Ready               bool             `json:"ready"`
 	}
 
-	st := readerStatus{AuthType: plugin.AuthType()}
+	meta := plugin.Metadata()
+	st := readerStatus{AuthType: meta.Auth.Type}
 
-	if plugin.RequiresCredentialsUpload() {
+	if meta.Auth.RequiresCredentialsUpload {
 		if h.store != nil {
 			_, ok, err := h.store.GetReaderSecret(r.Context(), name)
 			st.CredentialsUploaded = err == nil && ok
@@ -1041,7 +1049,7 @@ func (h *Handlers) HandleReaderStatus(w http.ResponseWriter, r *http.Request) {
 		st.CredentialsUploaded = true
 	}
 
-	if plugin.AuthType() == plugins.AuthTypeOAuth {
+	if meta.Auth.Type == plugins.AuthTypeOAuth {
 		if h.store != nil {
 			tokenJSON, ok, err := h.store.GetReaderToken(r.Context(), name)
 			if err == nil && ok {
@@ -1053,7 +1061,7 @@ func (h *Handlers) HandleReaderStatus(w http.ResponseWriter, r *http.Request) {
 		st.Authenticated = true
 	}
 
-	if len(plugin.ConfigSchema()) == 0 {
+	if len(meta.ConfigSchema) == 0 {
 		st.ConfigPresent = true
 	} else if h.store != nil {
 		_, ok, err := h.store.GetReaderConfig(r.Context(), name)
@@ -3033,7 +3041,7 @@ func (h *Handlers) HandleDiscoverMailboxes(w http.ResponseWriter, r *http.Reques
 }
 
 // HandleGetReaderGuide handles GET /api/readers/{name}/guide.
-// Returns the structured setup guide for a reader if it implements plugins.GuideProvider.
+// Returns the structured setup guide for a reader when metadata includes one.
 func (h *Handlers) HandleGetReaderGuide(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	plugin, err := h.registry.GetReader(name)
@@ -3041,13 +3049,13 @@ func (h *Handlers) HandleGetReaderGuide(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
 		return
 	}
-	gp, ok := plugin.(plugins.GuideProvider)
-	if !ok || gp.SetupGuide() == nil {
+	guideData := plugin.Metadata().SetupGuide
+	if len(guideData) == 0 {
 		writeError(w, http.StatusNotFound, "no setup guide available for this reader")
 		return
 	}
 	var guide plugins.ReaderGuide
-	if err := json.Unmarshal(gp.SetupGuide(), &guide); err != nil {
+	if err := json.Unmarshal(guideData, &guide); err != nil {
 		h.logger.Error("parsing reader guide", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to parse reader guide")
 		return

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -19,8 +20,6 @@ import (
 	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/internal/store"
 	pkgapi "github.com/ArionMiles/expensor/backend/pkg/api"
-	"github.com/ArionMiles/expensor/backend/pkg/config"
-	pkgstate "github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
 // --- mocks ---
@@ -576,37 +575,48 @@ func newTestHandlers(t *testing.T, st Storer, dm DaemonStatusProvider, banksData
 // --- minimal plugin stubs ---
 
 type testReaderPlugin struct {
-	name          string
-	authType      plugins.AuthType
-	requiresCreds bool
-	schema        []plugins.ConfigField
+	name              string
+	authType          plugins.AuthType
+	requiresCreds     bool
+	scopes            []string
+	schema            []plugins.ConfigField
+	preserveNilSchema bool
+	guide             json.RawMessage
 }
 
-func (p *testReaderPlugin) Name() string                    { return p.name }
-func (p *testReaderPlugin) Description() string             { return p.name + " reader" }
-func (p *testReaderPlugin) RequiredScopes() []string        { return []string{} }
-func (p *testReaderPlugin) AuthType() plugins.AuthType      { return p.authType }
-func (p *testReaderPlugin) RequiresCredentialsUpload() bool { return p.requiresCreds }
-func (p *testReaderPlugin) ConfigSchema() []plugins.ConfigField {
-	if p.schema == nil {
-		return []plugins.ConfigField{}
+func (p *testReaderPlugin) Metadata() plugins.ReaderMetadata {
+	schema := p.schema
+	if schema == nil && !p.preserveNilSchema {
+		schema = []plugins.ConfigField{}
 	}
-	return p.schema
+	return plugins.ReaderMetadata{
+		Name:        p.name,
+		Description: p.name + " reader",
+		Auth: plugins.AuthSpec{
+			Type:                      p.authType,
+			RequiredScopes:            p.scopes,
+			RequiresCredentialsUpload: p.requiresCreds,
+		},
+		ConfigSchema: schema,
+		SetupGuide:   p.guide,
+	}
 }
 
-func (p *testReaderPlugin) NewReader( //nolint:revive
-	_ *http.Client, _ *config.Config, _ []pkgapi.Rule,
-	_ pkgapi.CategoryResolver, _ *pkgstate.Manager, _ pkgapi.DiagnosticSink, _ *slog.Logger,
-) (pkgapi.Reader, error) {
+func (p *testReaderPlugin) NewReader(_ plugins.ReaderInput) (pkgapi.Reader, error) {
 	return nil, errors.New("not implemented in test stub")
 }
 
 type testWriterPlugin struct{ name string }
 
-func (p *testWriterPlugin) Name() string             { return p.name }
-func (p *testWriterPlugin) Description() string      { return p.name + " writer" }
-func (p *testWriterPlugin) RequiredScopes() []string { return []string{} }
-func (p *testWriterPlugin) NewWriter(_ *http.Client, _ *config.Config, _ *slog.Logger) (pkgapi.Writer, error) {
+func (p *testWriterPlugin) Metadata() plugins.WriterMetadata {
+	return plugins.WriterMetadata{
+		Name:           p.name,
+		Description:    p.name + " writer",
+		RequiredScopes: []string{},
+	}
+}
+
+func (p *testWriterPlugin) NewWriter(_ plugins.WriterInput) (pkgapi.Writer, error) {
 	return nil, errors.New("not implemented in test stub")
 }
 
@@ -703,6 +713,36 @@ func TestHandleListReaders(t *testing.T) {
 	}
 }
 
+func TestHandleListReaders_NormalizesNilConfigSchema(t *testing.T) {
+	h := newTestHandlers(t, nil, &mockDaemon{})
+	registry := plugins.NewRegistry()
+	if err := registry.RegisterReader(&testReaderPlugin{
+		name:              "nil-schema",
+		authType:          plugins.AuthTypeConfig,
+		preserveNilSchema: true,
+	}); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	h.registry = registry
+
+	rr := get(h.HandleListReaders, "/api/plugins/readers")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var readers []ReaderInfo
+	decodeJSON(t, rr.Body.String(), &readers)
+	if len(readers) != 1 {
+		t.Fatalf("expected 1 reader, got %d", len(readers))
+	}
+	if readers[0].ConfigSchema == nil {
+		t.Fatalf("config_schema = nil, want non-nil empty slice; body = %s", rr.Body.String())
+	}
+	if len(readers[0].ConfigSchema) != 0 {
+		t.Fatalf("config_schema len = %d, want 0", len(readers[0].ConfigSchema))
+	}
+}
+
 func TestHandleListWriters(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	rr := get(h.HandleListWriters, "/api/plugins/writers")
@@ -789,6 +829,50 @@ func TestHandleUploadCredentials_SavesToStore(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(h.dataDir, "client_secret_gmail.json")); !os.IsNotExist(err) {
 		t.Fatalf("credentials should not be written to disk, stat err=%v", err)
+	}
+}
+
+func TestHandleAuthStart_UsesMetadataScopes(t *testing.T) {
+	const expectedScope = "https://www.googleapis.com/auth/gmail.readonly"
+	secretJSON := `{
+		"installed": {
+			"client_id": "test-client-id.apps.googleusercontent.com",
+			"client_secret": "test-client-secret",
+			"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+			"token_uri": "https://oauth2.googleapis.com/token",
+			"redirect_uris": ["http://localhost:8080/api/auth/callback"]
+		}
+	}`
+	st := &mockStore{readerSecrets: map[string][]byte{"scoped": []byte(secretJSON)}}
+	h := newTestHandlers(t, st, &mockDaemon{})
+	registry := plugins.NewRegistry()
+	if err := registry.RegisterReader(&testReaderPlugin{
+		name:          "scoped",
+		authType:      plugins.AuthTypeOAuth,
+		requiresCreds: true,
+		scopes:        []string{expectedScope},
+	}); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	h.registry = registry
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/scoped/auth/start", nil)
+	req.SetPathValue("name", "scoped")
+	rr := httptest.NewRecorder()
+
+	h.HandleAuthStart(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	decodeJSON(t, rr.Body.String(), &resp)
+	authURL, err := url.Parse(resp["url"])
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+	if got := authURL.Query().Get("scope"); got != expectedScope {
+		t.Fatalf("scope = %q, want %q (url: %s)", got, expectedScope, resp["url"])
 	}
 }
 
@@ -2948,15 +3032,44 @@ func TestHandleDiscoverMailboxes_NonexistentProfile_Returns404(t *testing.T) {
 }
 
 func TestHandleGetReaderGuide_NoGuide_Returns404(t *testing.T) {
-	// testReaderPlugin (used by newTestHandlers) does not implement GuideProvider.
 	h := newTestHandlers(t, nil, &mockDaemon{})
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/gmail/guide", nil)
-	req.SetPathValue("name", "gmail")
+	registry := plugins.NewRegistry()
+	if err := registry.RegisterReader(&testReaderPlugin{name: "noguide", authType: plugins.AuthTypeConfig}); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	h.registry = registry
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/noguide/guide", nil)
+	req.SetPathValue("name", "noguide")
 	rr := httptest.NewRecorder()
+
 	h.HandleGetReaderGuide(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleGetReaderGuide_ReturnsMetadataGuide(t *testing.T) {
+	h := newTestHandlers(t, nil, &mockDaemon{})
+	registry := plugins.NewRegistry()
+	guide := json.RawMessage(`{"sections":[{"title":"Setup","steps":[{"text":"Do the setup"}]}]}`)
+	if err := registry.RegisterReader(&testReaderPlugin{name: "guided", authType: plugins.AuthTypeConfig, guide: guide}); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	h.registry = registry
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/guided/guide", nil)
+	req.SetPathValue("name", "guided")
+	rr := httptest.NewRecorder()
+
+	h.HandleGetReaderGuide(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Do the setup") {
+		t.Fatalf("body = %s, want setup guide", rr.Body.String())
 	}
 }
 

--- a/backend/internal/daemon/runner.go
+++ b/backend/internal/daemon/runner.go
@@ -71,37 +71,33 @@ func (r *Runner) Run(ctx context.Context, runCfg RunConfig) error {
 		"writer", runCfg.WriterName,
 	)
 
-	// Overlay persisted web-UI config onto cfg for readers that use ConfigApplier.
-	applyPersistedReaderConfig(ctx, persistedReaderConfigInput{
-		registry:   r.registry,
-		readerName: runCfg.ReaderName,
-		config:     runCfg.Config,
-		store:      runCfg.RuntimeStore,
-		logger:     r.logger,
+	readerPlugin, err := r.registry.GetReader(runCfg.ReaderName)
+	if err != nil {
+		return fmt.Errorf("creating reader: %w", err)
+	}
+	reader, err := readerPlugin.NewReader(plugins.ReaderInput{
+		HTTPClient:     r.httpClient,
+		AppConfig:      cfg,
+		ReaderConfig:   r.loadReaderConfig(ctx, runCfg.ReaderName, runCfg.RuntimeStore),
+		Rules:          runCfg.Rules,
+		Resolver:       runCfg.Resolver,
+		StateManager:   runCfg.StateManager,
+		DiagnosticSink: runCfg.DiagnosticSink,
+		Logger:         r.logger.With("component", "reader", "plugin", runCfg.ReaderName),
 	})
-
-	// Create reader from plugin
-	reader, err := r.registry.CreateReader(
-		runCfg.ReaderName,
-		r.httpClient,
-		cfg,
-		runCfg.Rules,
-		runCfg.Resolver,
-		runCfg.StateManager,
-		runCfg.DiagnosticSink,
-		r.logger.With("component", "reader", "plugin", runCfg.ReaderName),
-	)
 	if err != nil {
 		return fmt.Errorf("creating reader: %w", err)
 	}
 
-	// Create writer from plugin
-	writer, err := r.registry.CreateWriter(
-		runCfg.WriterName,
-		r.httpClient,
-		cfg,
-		r.logger.With("component", "writer", "plugin", runCfg.WriterName),
-	)
+	writerPlugin, err := r.registry.GetWriter(runCfg.WriterName)
+	if err != nil {
+		return fmt.Errorf("creating writer: %w", err)
+	}
+	writer, err := writerPlugin.NewWriter(plugins.WriterInput{
+		HTTPClient: r.httpClient,
+		AppConfig:  cfg,
+		Logger:     r.logger.With("component", "writer", "plugin", runCfg.WriterName),
+	})
 	if err != nil {
 		return fmt.Errorf("creating writer: %w", err)
 	}
@@ -135,42 +131,17 @@ func (r *Runner) Run(ctx context.Context, runCfg RunConfig) error {
 	return nil
 }
 
-type persistedReaderConfigInput struct {
-	registry   *plugins.Registry
-	readerName string
-	config     *config.Config
-	store      ReaderRuntimeStore
-	logger     *slog.Logger
-}
-
-// applyPersistedReaderConfig loads DB-backed reader config and, if the plugin
-// implements ConfigApplier, overlays its values onto cfg. Errors are non-fatal:
-// if config is absent the reader falls back to env vars.
-func applyPersistedReaderConfig(ctx context.Context, input persistedReaderConfigInput) {
-	plugin, err := input.registry.GetReader(input.readerName)
+func (r *Runner) loadReaderConfig(ctx context.Context, readerName string, store ReaderRuntimeStore) json.RawMessage {
+	if store == nil {
+		return nil
+	}
+	data, ok, err := store.GetReaderConfig(ctx, readerName)
 	if err != nil {
-		return
-	}
-	applier, ok := plugin.(plugins.ConfigApplier)
-	if !ok {
-		return
-	}
-	if input.store == nil {
-		return
-	}
-	data, ok, err := input.store.GetReaderConfig(ctx, input.readerName)
-	if err != nil {
-		input.logger.Warn("failed to read persisted reader config", "reader", input.readerName, "error", err)
-		return
+		r.logger.Warn("failed to read persisted reader config", "reader", readerName, "error", err)
+		return nil
 	}
 	if !ok {
-		return
+		return nil
 	}
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		input.logger.Warn("failed to parse persisted reader config", "reader", input.readerName, "error", err)
-		return
-	}
-	applier.ApplyConfig(input.config, raw)
-	input.logger.Debug("applied persisted reader config", "reader", input.readerName)
+	return data
 }

--- a/backend/internal/daemon/runner_test.go
+++ b/backend/internal/daemon/runner_test.go
@@ -457,7 +457,7 @@ func TestRun_ContextCancellation(t *testing.T) {
 	}
 }
 
-func TestRun_CreateReaderError(t *testing.T) {
+func TestRun_NewReaderError(t *testing.T) {
 	registry := plugins.NewRegistry()
 	if err := registry.RegisterReader(&mockReaderPlugin{
 		name:        "test-reader",
@@ -494,7 +494,7 @@ func TestRun_CreateReaderError(t *testing.T) {
 	}
 }
 
-func TestRun_CreateWriterError(t *testing.T) {
+func TestRun_NewWriterError(t *testing.T) {
 	reader := &mockReader{
 		readFunc: func(ctx context.Context, out chan<- *api.TransactionDetails, ackChan <-chan string) error {
 			close(out)

--- a/backend/internal/daemon/runner_test.go
+++ b/backend/internal/daemon/runner_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -14,7 +15,6 @@ import (
 	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
-	"github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
 // mockReader implements api.Reader for testing.
@@ -58,18 +58,22 @@ type mockReaderPlugin struct {
 	name        string
 	reader      api.Reader
 	createError error
+	input       plugins.ReaderInput
 }
 
-func (m *mockReaderPlugin) Name() string                        { return m.name }
-func (m *mockReaderPlugin) Description() string                 { return "mock reader" }
-func (m *mockReaderPlugin) RequiredScopes() []string            { return []string{"scope1"} }
-func (m *mockReaderPlugin) AuthType() plugins.AuthType          { return plugins.AuthTypeOAuth }
-func (m *mockReaderPlugin) RequiresCredentialsUpload() bool     { return false }
-func (m *mockReaderPlugin) ConfigSchema() []plugins.ConfigField { return nil }
-func (m *mockReaderPlugin) NewReader( //nolint:revive // interface method; argument count dictated by ReaderPlugin
-	httpClient *http.Client, cfg *config.Config, rules []api.Rule,
-	resolver api.CategoryResolver, stateManager *state.Manager, diagnosticSink api.DiagnosticSink, logger *slog.Logger,
-) (api.Reader, error) {
+func (m *mockReaderPlugin) Metadata() plugins.ReaderMetadata {
+	return plugins.ReaderMetadata{
+		Name:        m.name,
+		Description: "mock reader",
+		Auth: plugins.AuthSpec{
+			Type:           plugins.AuthTypeOAuth,
+			RequiredScopes: []string{"scope1"},
+		},
+	}
+}
+
+func (m *mockReaderPlugin) NewReader(input plugins.ReaderInput) (api.Reader, error) {
+	m.input = input
 	if m.createError != nil {
 		return nil, m.createError
 	}
@@ -81,16 +85,33 @@ type mockWriterPlugin struct {
 	name        string
 	writer      api.Writer
 	createError error
+	input       plugins.WriterInput
 }
 
-func (m *mockWriterPlugin) Name() string             { return m.name }
-func (m *mockWriterPlugin) Description() string      { return "mock writer" }
-func (m *mockWriterPlugin) RequiredScopes() []string { return []string{"scope2"} }
-func (m *mockWriterPlugin) NewWriter(httpClient *http.Client, cfg *config.Config, logger *slog.Logger) (api.Writer, error) {
+func (m *mockWriterPlugin) Metadata() plugins.WriterMetadata {
+	return plugins.WriterMetadata{
+		Name:           m.name,
+		Description:    "mock writer",
+		RequiredScopes: []string{"scope2"},
+	}
+}
+
+func (m *mockWriterPlugin) NewWriter(input plugins.WriterInput) (api.Writer, error) {
+	m.input = input
 	if m.createError != nil {
 		return nil, m.createError
 	}
 	return m.writer, nil
+}
+
+type mockRuntimeStore struct {
+	readerConfig json.RawMessage
+	hasConfig    bool
+	err          error
+}
+
+func (m *mockRuntimeStore) GetReaderConfig(ctx context.Context, reader string) (json.RawMessage, bool, error) {
+	return m.readerConfig, m.hasConfig, m.err
 }
 
 func TestNew(t *testing.T) {
@@ -321,6 +342,46 @@ func TestRun_WriterError(t *testing.T) {
 	err := runner.Run(ctx, runCfg)
 	if err != nil {
 		t.Errorf("Run should not return error, got: %v", err)
+	}
+}
+
+func TestRun_PassesPersistedReaderConfigToPlugin(t *testing.T) {
+	reader := &mockReader{
+		readFunc: func(ctx context.Context, out chan<- *api.TransactionDetails, ackChan <-chan string) error {
+			close(out)
+			return nil
+		},
+	}
+	writer := &mockWriter{}
+	readerPlugin := &mockReaderPlugin{name: "test-reader", reader: reader}
+	writerPlugin := &mockWriterPlugin{name: "test-writer", writer: writer}
+	registry := plugins.NewRegistry()
+	if err := registry.RegisterReader(readerPlugin); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	if err := registry.RegisterWriter(writerPlugin); err != nil {
+		t.Fatalf("RegisterWriter() error = %v", err)
+	}
+
+	runtimeStore := &mockRuntimeStore{
+		readerConfig: json.RawMessage(`{"config":{"profilePath":"/tmp/profile","mailboxes":"Inbox"}}`),
+		hasConfig:    true,
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	runner := New(registry, &http.Client{}, logger)
+
+	err := runner.Run(context.Background(), RunConfig{
+		ReaderName:   "test-reader",
+		WriterName:   "test-writer",
+		Config:       &config.Config{},
+		RuntimeStore: runtimeStore,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if string(readerPlugin.input.ReaderConfig) != string(runtimeStore.readerConfig) {
+		t.Fatalf("ReaderConfig = %s, want %s", readerPlugin.input.ReaderConfig, runtimeStore.readerConfig)
 	}
 }
 

--- a/backend/internal/plugins/registry.go
+++ b/backend/internal/plugins/registry.go
@@ -2,9 +2,12 @@
 package plugins
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"reflect"
+	"strings"
 
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
@@ -31,16 +34,46 @@ type ConfigField struct {
 	DependsOn string `json:"depends_on,omitempty"`
 }
 
-// GuideProvider is an optional interface for reader plugins that provide setup guides.
-type GuideProvider interface {
-	SetupGuide() []byte
+// AuthSpec describes how a reader plugin authenticates.
+type AuthSpec struct {
+	Type                      AuthType `json:"type"`
+	RequiredScopes            []string `json:"required_scopes"`
+	RequiresCredentialsUpload bool     `json:"requires_credentials_upload"`
 }
 
-// ConfigApplier is an optional interface for reader plugins whose settings are
-// persisted via the web UI (POST /api/readers/{name}/config) rather than env vars.
-// Implement this to map the raw JSON config map onto config.Config before the daemon starts.
-type ConfigApplier interface {
-	ApplyConfig(cfg *config.Config, raw map[string]any)
+// ReaderMetadata describes a reader plugin for catalog display and selection.
+type ReaderMetadata struct {
+	Name         string          `json:"name"`
+	Description  string          `json:"description"`
+	Auth         AuthSpec        `json:"auth"`
+	ConfigSchema []ConfigField   `json:"config_schema"`
+	SetupGuide   json.RawMessage `json:"setup_guide,omitempty"`
+}
+
+// WriterMetadata describes a writer plugin for catalog display and selection.
+type WriterMetadata struct {
+	Name           string   `json:"name"`
+	Description    string   `json:"description"`
+	RequiredScopes []string `json:"required_scopes"`
+}
+
+// ReaderInput contains dependencies required to create a reader instance.
+type ReaderInput struct {
+	HTTPClient     *http.Client
+	AppConfig      *config.Config
+	ReaderConfig   json.RawMessage
+	Rules          []api.Rule
+	Resolver       api.CategoryResolver
+	StateManager   *state.Manager
+	DiagnosticSink api.DiagnosticSink
+	Logger         *slog.Logger
+}
+
+// WriterInput contains dependencies required to create a writer instance.
+type WriterInput struct {
+	HTTPClient *http.Client
+	AppConfig  *config.Config
+	Logger     *slog.Logger
 }
 
 // ReaderGuide is the structured setup guide for a reader plugin.
@@ -77,38 +110,14 @@ type GuideNote struct {
 
 // ReaderPlugin defines the interface for transaction reader plugins.
 type ReaderPlugin interface {
-	// Name returns the plugin name (e.g., "gmail", "thunderbird").
-	Name() string
-	// Description returns a human-readable description.
-	Description() string
-	// RequiredScopes returns the OAuth scopes needed by this plugin.
-	RequiredScopes() []string
-	// AuthType returns how this reader authenticates.
-	AuthType() AuthType
-	// RequiresCredentialsUpload reports whether the user must upload an OAuth
-	// client credentials file (e.g. client_secret.json for Gmail).
-	RequiresCredentialsUpload() bool
-	// ConfigSchema returns the configuration fields the user must provide.
-	// For OAuth readers this is typically empty; for config-only readers
-	// (e.g. Thunderbird) it describes the required fields.
-	ConfigSchema() []ConfigField
-	// NewReader creates a new reader instance with the given config.
-	NewReader(
-		httpClient *http.Client, cfg *config.Config, rules []api.Rule,
-		resolver api.CategoryResolver, stateManager *state.Manager, diagnosticSink api.DiagnosticSink, logger *slog.Logger,
-	) (api.Reader, error)
+	Metadata() ReaderMetadata
+	NewReader(input ReaderInput) (api.Reader, error)
 }
 
 // WriterPlugin defines the interface for transaction writer plugins.
 type WriterPlugin interface {
-	// Name returns the plugin name (e.g., "sheets", "postgres").
-	Name() string
-	// Description returns a human-readable description.
-	Description() string
-	// RequiredScopes returns the OAuth scopes needed by this plugin.
-	RequiredScopes() []string
-	// NewWriter creates a new writer instance with the given config.
-	NewWriter(httpClient *http.Client, cfg *config.Config, logger *slog.Logger) (api.Writer, error)
+	Metadata() WriterMetadata
+	NewWriter(input WriterInput) (api.Writer, error)
 }
 
 // Registry manages available reader and writer plugins.
@@ -127,7 +136,18 @@ func NewRegistry() *Registry {
 
 // RegisterReader registers a reader plugin.
 func (r *Registry) RegisterReader(plugin ReaderPlugin) error {
-	name := plugin.Name()
+	if isNilPlugin(plugin) {
+		return fmt.Errorf("reader plugin is nil")
+	}
+
+	metadata := plugin.Metadata()
+	name := metadata.Name
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("reader plugin name is required")
+	}
+	if len(metadata.SetupGuide) > 0 && !json.Valid(metadata.SetupGuide) {
+		return fmt.Errorf("reader plugin %q setup guide must be valid JSON", name)
+	}
 	if _, exists := r.readers[name]; exists {
 		return fmt.Errorf("reader plugin %q already registered", name)
 	}
@@ -137,7 +157,14 @@ func (r *Registry) RegisterReader(plugin ReaderPlugin) error {
 
 // RegisterWriter registers a writer plugin.
 func (r *Registry) RegisterWriter(plugin WriterPlugin) error {
-	name := plugin.Name()
+	if isNilPlugin(plugin) {
+		return fmt.Errorf("writer plugin is nil")
+	}
+
+	name := plugin.Metadata().Name
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("writer plugin name is required")
+	}
 	if _, exists := r.writers[name]; exists {
 		return fmt.Errorf("writer plugin %q already registered", name)
 	}
@@ -195,10 +222,10 @@ func (r *Registry) GetAllScopes(readerName, writerName string) ([]string, error)
 
 	// Combine and deduplicate scopes
 	scopeSet := make(map[string]struct{})
-	for _, scope := range reader.RequiredScopes() {
+	for _, scope := range reader.Metadata().Auth.RequiredScopes {
 		scopeSet[scope] = struct{}{}
 	}
-	for _, scope := range writer.RequiredScopes() {
+	for _, scope := range writer.Metadata().RequiredScopes {
 		scopeSet[scope] = struct{}{}
 	}
 
@@ -210,23 +237,16 @@ func (r *Registry) GetAllScopes(readerName, writerName string) ([]string, error)
 	return scopes, nil
 }
 
-// CreateReader creates a reader instance from a plugin.
-func (r *Registry) CreateReader( //nolint:revive // argument count mirrors the ReaderPlugin interface
-	name string, httpClient *http.Client, cfg *config.Config, rules []api.Rule,
-	resolver api.CategoryResolver, stateManager *state.Manager, diagnosticSink api.DiagnosticSink, logger *slog.Logger,
-) (api.Reader, error) {
-	plugin, err := r.GetReader(name)
-	if err != nil {
-		return nil, err
+func isNilPlugin(plugin any) bool {
+	if plugin == nil {
+		return true
 	}
-	return plugin.NewReader(httpClient, cfg, rules, resolver, stateManager, diagnosticSink, logger)
-}
 
-// CreateWriter creates a writer instance from a plugin.
-func (r *Registry) CreateWriter(name string, httpClient *http.Client, cfg *config.Config, logger *slog.Logger) (api.Writer, error) {
-	plugin, err := r.GetWriter(name)
-	if err != nil {
-		return nil, err
+	value := reflect.ValueOf(plugin)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
 	}
-	return plugin.NewWriter(httpClient, cfg, logger)
 }

--- a/backend/internal/plugins/registry_test.go
+++ b/backend/internal/plugins/registry_test.go
@@ -2,15 +2,9 @@ package plugins
 
 import (
 	"context"
-	"errors"
-	"log/slog"
-	"net/http"
-	"os"
 	"testing"
 
 	"github.com/ArionMiles/expensor/backend/pkg/api"
-	"github.com/ArionMiles/expensor/backend/pkg/config"
-	"github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
 // mockReader implements api.Reader for testing.
@@ -32,23 +26,32 @@ type mockReaderPlugin struct {
 	name        string
 	description string
 	scopes      []string
-	createError error
+	guide       []byte
+	reader      api.Reader
+	err         error
+	input       ReaderInput
 }
 
-func (m *mockReaderPlugin) Name() string                    { return m.name }
-func (m *mockReaderPlugin) Description() string             { return m.description }
-func (m *mockReaderPlugin) RequiredScopes() []string        { return m.scopes }
-func (m *mockReaderPlugin) AuthType() AuthType              { return AuthTypeOAuth }
-func (m *mockReaderPlugin) RequiresCredentialsUpload() bool { return false }
-func (m *mockReaderPlugin) ConfigSchema() []ConfigField     { return nil }
-func (m *mockReaderPlugin) NewReader( //nolint:revive // interface method; argument count dictated by ReaderPlugin
-	httpClient *http.Client, cfg *config.Config, rules []api.Rule,
-	resolver api.CategoryResolver, stateManager *state.Manager, diagnosticSink api.DiagnosticSink, logger *slog.Logger,
-) (api.Reader, error) {
-	if m.createError != nil {
-		return nil, m.createError
+func (m *mockReaderPlugin) Metadata() ReaderMetadata {
+	return ReaderMetadata{
+		Name:        m.name,
+		Description: m.description,
+		Auth: AuthSpec{
+			Type:                      AuthTypeOAuth,
+			RequiredScopes:            m.scopes,
+			RequiresCredentialsUpload: false,
+		},
+		ConfigSchema: nil,
+		SetupGuide:   m.guide,
 	}
-	return &mockReader{}, nil
+}
+
+func (m *mockReaderPlugin) NewReader(input ReaderInput) (api.Reader, error) {
+	m.input = input
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.reader, nil
 }
 
 // mockWriterPlugin implements WriterPlugin for testing.
@@ -56,17 +59,21 @@ type mockWriterPlugin struct {
 	name        string
 	description string
 	scopes      []string
-	createError error
+	writer      api.Writer
+	err         error
+	input       WriterInput
 }
 
-func (m *mockWriterPlugin) Name() string             { return m.name }
-func (m *mockWriterPlugin) Description() string      { return m.description }
-func (m *mockWriterPlugin) RequiredScopes() []string { return m.scopes }
-func (m *mockWriterPlugin) NewWriter(httpClient *http.Client, cfg *config.Config, logger *slog.Logger) (api.Writer, error) {
-	if m.createError != nil {
-		return nil, m.createError
+func (m *mockWriterPlugin) Metadata() WriterMetadata {
+	return WriterMetadata{Name: m.name, Description: m.description, RequiredScopes: m.scopes}
+}
+
+func (m *mockWriterPlugin) NewWriter(input WriterInput) (api.Writer, error) {
+	m.input = input
+	if m.err != nil {
+		return nil, m.err
 	}
-	return &mockWriter{}, nil
+	return m.writer, nil
 }
 
 func TestNewRegistry(t *testing.T) {
@@ -116,12 +123,12 @@ func TestRegisterReader(t *testing.T) {
 			}
 
 			if !tt.wantErr {
-				plugin, err := registry.GetReader(tt.plugin.Name())
+				plugin, err := registry.GetReader(tt.plugin.Metadata().Name)
 				if err != nil {
 					t.Errorf("failed to get registered reader: %v", err)
 				}
-				if plugin.Name() != tt.plugin.Name() {
-					t.Errorf("expected plugin name %q, got %q", tt.plugin.Name(), plugin.Name())
+				if plugin.Metadata().Name != tt.plugin.Metadata().Name {
+					t.Errorf("expected plugin name %q, got %q", tt.plugin.Metadata().Name, plugin.Metadata().Name)
 				}
 			}
 		})
@@ -146,6 +153,57 @@ func TestRegisterReader_Duplicate(t *testing.T) {
 	expectedErr := `reader plugin "test-reader" already registered`
 	if err.Error() != expectedErr {
 		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+}
+
+func TestRegisterReader_RejectsNilPlugin(t *testing.T) {
+	registry := NewRegistry()
+
+	assertNotPanics(t, func() {
+		err := registry.RegisterReader(nil)
+		if err == nil {
+			t.Fatal("expected error for nil reader plugin, got nil")
+		}
+	})
+}
+
+func TestRegisterReader_RejectsTypedNilPlugin(t *testing.T) {
+	registry := NewRegistry()
+	var plugin *mockReaderPlugin
+
+	assertNotPanics(t, func() {
+		err := registry.RegisterReader(plugin)
+		if err == nil {
+			t.Fatal("expected error for typed nil reader plugin, got nil")
+		}
+	})
+}
+
+func TestRegisterReader_RejectsBlankName(t *testing.T) {
+	tests := []struct {
+		name       string
+		readerName string
+	}{
+		{name: "empty", readerName: ""},
+		{name: "whitespace", readerName: " \t\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewRegistry()
+			err := registry.RegisterReader(&mockReaderPlugin{name: tt.readerName})
+			if err == nil {
+				t.Fatal("expected error for blank reader name, got nil")
+			}
+		})
+	}
+}
+
+func TestRegisterReader_RejectsInvalidSetupGuideJSON(t *testing.T) {
+	registry := NewRegistry()
+	err := registry.RegisterReader(&mockReaderPlugin{name: "test-reader", guide: []byte("{invalid")})
+	if err == nil {
+		t.Fatal("expected error for invalid setup guide JSON, got nil")
 	}
 }
 
@@ -176,12 +234,12 @@ func TestRegisterWriter(t *testing.T) {
 			}
 
 			if !tt.wantErr {
-				plugin, err := registry.GetWriter(tt.plugin.Name())
+				plugin, err := registry.GetWriter(tt.plugin.Metadata().Name)
 				if err != nil {
 					t.Errorf("failed to get registered writer: %v", err)
 				}
-				if plugin.Name() != tt.plugin.Name() {
-					t.Errorf("expected plugin name %q, got %q", tt.plugin.Name(), plugin.Name())
+				if plugin.Metadata().Name != tt.plugin.Metadata().Name {
+					t.Errorf("expected plugin name %q, got %q", tt.plugin.Metadata().Name, plugin.Metadata().Name)
 				}
 			}
 		})
@@ -206,6 +264,49 @@ func TestRegisterWriter_Duplicate(t *testing.T) {
 	expectedErr := `writer plugin "test-writer" already registered`
 	if err.Error() != expectedErr {
 		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+}
+
+func TestRegisterWriter_RejectsNilPlugin(t *testing.T) {
+	registry := NewRegistry()
+
+	assertNotPanics(t, func() {
+		err := registry.RegisterWriter(nil)
+		if err == nil {
+			t.Fatal("expected error for nil writer plugin, got nil")
+		}
+	})
+}
+
+func TestRegisterWriter_RejectsTypedNilPlugin(t *testing.T) {
+	registry := NewRegistry()
+	var plugin *mockWriterPlugin
+
+	assertNotPanics(t, func() {
+		err := registry.RegisterWriter(plugin)
+		if err == nil {
+			t.Fatal("expected error for typed nil writer plugin, got nil")
+		}
+	})
+}
+
+func TestRegisterWriter_RejectsBlankName(t *testing.T) {
+	tests := []struct {
+		name       string
+		writerName string
+	}{
+		{name: "empty", writerName: ""},
+		{name: "whitespace", writerName: " \t\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewRegistry()
+			err := registry.RegisterWriter(&mockWriterPlugin{name: tt.writerName})
+			if err == nil {
+				t.Fatal("expected error for blank writer name, got nil")
+			}
+		})
 	}
 }
 
@@ -253,8 +354,8 @@ func TestGetReader(t *testing.T) {
 			if !tt.wantErr && got == nil {
 				t.Error("expected plugin, got nil")
 			}
-			if !tt.wantErr && got != nil && got.Name() != tt.pluginName {
-				t.Errorf("expected plugin name %q, got %q", tt.pluginName, got.Name())
+			if !tt.wantErr && got != nil && got.Metadata().Name != tt.pluginName {
+				t.Errorf("expected plugin name %q, got %q", tt.pluginName, got.Metadata().Name)
 			}
 		})
 	}
@@ -304,8 +405,8 @@ func TestGetWriter(t *testing.T) {
 			if !tt.wantErr && got == nil {
 				t.Error("expected plugin, got nil")
 			}
-			if !tt.wantErr && got != nil && got.Name() != tt.pluginName {
-				t.Errorf("expected plugin name %q, got %q", tt.pluginName, got.Name())
+			if !tt.wantErr && got != nil && got.Metadata().Name != tt.pluginName {
+				t.Errorf("expected plugin name %q, got %q", tt.pluginName, got.Metadata().Name)
 			}
 		})
 	}
@@ -339,7 +440,7 @@ func TestListReaders(t *testing.T) {
 	// Verify both are present (order not guaranteed)
 	names := make(map[string]bool)
 	for _, r := range readers {
-		names[r.Name()] = true
+		names[r.Metadata().Name] = true
 	}
 	if !names["reader1"] {
 		t.Error("reader1 not found in list")
@@ -377,7 +478,7 @@ func TestListWriters(t *testing.T) {
 	// Verify both are present (order not guaranteed)
 	names := make(map[string]bool)
 	for _, w := range writers {
-		names[w.Name()] = true
+		names[w.Metadata().Name] = true
 	}
 	if !names["writer1"] {
 		t.Error("writer1 not found in list")
@@ -491,112 +592,41 @@ func TestGetAllScopes_WriterNotFound(t *testing.T) {
 	}
 }
 
-func TestCreateReader(t *testing.T) {
-	tests := []struct {
-		name        string
-		createError error
-		wantErr     bool
-	}{
-		{
-			name:        "successful creation",
-			createError: nil,
-			wantErr:     false,
-		},
-		{
-			name:        "creation error",
-			createError: errors.New("failed to create"),
-			wantErr:     true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			registry := NewRegistry()
-			plugin := &mockReaderPlugin{
-				name:        "test-reader",
-				createError: tt.createError,
-			}
-			if err := registry.RegisterReader(plugin); err != nil {
-				t.Fatalf("RegisterReader: %v", err)
-			}
-
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-			cfg := &config.Config{}
-			reader, err := registry.CreateReader("test-reader", &http.Client{}, cfg, []api.Rule{}, nil, nil, nil, logger)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateReader() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if !tt.wantErr && reader == nil {
-				t.Error("expected reader, got nil")
-			}
-		})
-	}
-}
-
-func TestCreateReader_NotFound(t *testing.T) {
+func TestRegistryIsCatalogOnly(t *testing.T) {
 	registry := NewRegistry()
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	cfg := &config.Config{}
+	reader := &mockReaderPlugin{name: "test-reader", reader: &mockReader{}}
+	writer := &mockWriterPlugin{name: "test-writer", writer: &mockWriter{}}
 
-	_, err := registry.CreateReader("unknown", &http.Client{}, cfg, []api.Rule{}, nil, nil, nil, logger)
-	if err == nil {
-		t.Fatal("expected error for unknown reader, got nil")
+	if err := registry.RegisterReader(reader); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	if err := registry.RegisterWriter(writer); err != nil {
+		t.Fatalf("RegisterWriter() error = %v", err)
+	}
+
+	gotReader, err := registry.GetReader("test-reader")
+	if err != nil {
+		t.Fatalf("GetReader() error = %v", err)
+	}
+	if gotReader.Metadata().Name != "test-reader" {
+		t.Fatalf("reader name = %q, want test-reader", gotReader.Metadata().Name)
+	}
+
+	gotWriter, err := registry.GetWriter("test-writer")
+	if err != nil {
+		t.Fatalf("GetWriter() error = %v", err)
+	}
+	if gotWriter.Metadata().Name != "test-writer" {
+		t.Fatalf("writer name = %q, want test-writer", gotWriter.Metadata().Name)
 	}
 }
 
-func TestCreateWriter(t *testing.T) {
-	tests := []struct {
-		name        string
-		createError error
-		wantErr     bool
-	}{
-		{
-			name:        "successful creation",
-			createError: nil,
-			wantErr:     false,
-		},
-		{
-			name:        "creation error",
-			createError: errors.New("failed to create"),
-			wantErr:     true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			registry := NewRegistry()
-			plugin := &mockWriterPlugin{
-				name:        "test-writer",
-				createError: tt.createError,
-			}
-			if err := registry.RegisterWriter(plugin); err != nil {
-				t.Fatalf("RegisterWriter: %v", err)
-			}
-
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-			cfg := &config.Config{}
-			writer, err := registry.CreateWriter("test-writer", &http.Client{}, cfg, logger)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateWriter() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if !tt.wantErr && writer == nil {
-				t.Error("expected writer, got nil")
-			}
-		})
-	}
-}
-
-func TestCreateWriter_NotFound(t *testing.T) {
-	registry := NewRegistry()
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	cfg := &config.Config{}
-
-	_, err := registry.CreateWriter("unknown", &http.Client{}, cfg, logger)
-	if err == nil {
-		t.Fatal("expected error for unknown writer, got nil")
-	}
+func assertNotPanics(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("unexpected panic: %v", recovered)
+		}
+	}()
+	fn()
 }

--- a/backend/pkg/plugins/readers/gmail/plugin.go
+++ b/backend/pkg/plugins/readers/gmail/plugin.go
@@ -2,8 +2,6 @@
 package gmail
 
 import (
-	"log/slog"
-	"net/http"
 	"time"
 
 	gmailapi "google.golang.org/api/gmail/v1"
@@ -12,7 +10,6 @@ import (
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
 	gmailreader "github.com/ArionMiles/expensor/backend/pkg/reader/gmail"
-	"github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
 // Plugin implements the ReaderPlugin interface for Gmail.
@@ -24,50 +21,41 @@ type Plugin struct {
 // the centralized content/readers/gmail/guide.json via go:embed.
 func (p *Plugin) SetGuideData(data []byte) { p.guideData = data }
 
-// Name returns the plugin name.
-func (p *Plugin) Name() string { return "gmail" }
-
-// Description returns a human-readable description.
-func (p *Plugin) Description() string {
-	return "Read expense transactions from Gmail messages"
+// Metadata returns catalog metadata for the Gmail reader plugin.
+func (p *Plugin) Metadata() plugins.ReaderMetadata {
+	return plugins.ReaderMetadata{
+		Name:        "gmail",
+		Description: "Read expense transactions from Gmail messages",
+		Auth: plugins.AuthSpec{
+			Type:                      plugins.AuthTypeOAuth,
+			RequiredScopes:            []string{gmailapi.GmailReadonlyScope},
+			RequiresCredentialsUpload: true,
+		},
+		ConfigSchema: []plugins.ConfigField{},
+		SetupGuide:   p.guideData,
+	}
 }
-
-// RequiredScopes returns the OAuth scopes needed by this plugin.
-func (p *Plugin) RequiredScopes() []string {
-	return []string{gmailapi.GmailReadonlyScope}
-}
-
-// AuthType returns the authentication type for Gmail (OAuth2).
-func (p *Plugin) AuthType() plugins.AuthType { return plugins.AuthTypeOAuth }
-
-// RequiresCredentialsUpload reports that Gmail needs a client_secret.json upload.
-func (p *Plugin) RequiresCredentialsUpload() bool { return true }
-
-// ConfigSchema returns an empty schema — Gmail is configured via OAuth, not form fields.
-func (p *Plugin) ConfigSchema() []plugins.ConfigField { return []plugins.ConfigField{} }
-
-// SetupGuide returns the injected setup guide for Gmail.
-func (p *Plugin) SetupGuide() []byte { return p.guideData }
 
 // NewReader creates a new Gmail reader instance.
-func (p *Plugin) NewReader( //nolint:revive // interface method; argument count dictated by ReaderPlugin
-	httpClient *http.Client, cfg *config.Config, rules []api.Rule,
-	resolver api.CategoryResolver, stateManager *state.Manager, diagnosticSink api.DiagnosticSink, logger *slog.Logger,
-) (api.Reader, error) {
+func (p *Plugin) NewReader(input plugins.ReaderInput) (api.Reader, error) {
+	cfg := input.AppConfig
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
 	interval := time.Duration(cfg.ScanInterval) * time.Second
 	if interval == 0 {
 		interval = 60 * time.Second
 	}
 	readerCfg := gmailreader.Config{
-		Rules:          rules,
-		Resolver:       resolver,
+		Rules:          input.Rules,
+		Resolver:       input.Resolver,
 		Interval:       interval,
-		State:          stateManager,
+		State:          input.StateManager,
 		LookbackDays:   cfg.LookbackDays,
 		LastScanAt:     cfg.LastScanAt,
 		ForceFullScan:  cfg.ForceFullScan,
 		OnCheckpoint:   cfg.OnCheckpoint,
-		DiagnosticSink: diagnosticSink,
+		DiagnosticSink: input.DiagnosticSink,
 	}
-	return gmailreader.New(httpClient, readerCfg, logger)
+	return gmailreader.New(input.HTTPClient, readerCfg, input.Logger)
 }

--- a/backend/pkg/plugins/readers/gmail/plugin_test.go
+++ b/backend/pkg/plugins/readers/gmail/plugin_test.go
@@ -7,6 +7,7 @@ import (
 
 	gmailapi "google.golang.org/api/gmail/v1"
 
+	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
 	gmailplugin "github.com/ArionMiles/expensor/backend/pkg/plugins/readers/gmail"
 )
@@ -15,28 +16,29 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
-func TestPlugin_Name(t *testing.T) {
+func TestPlugin_Metadata(t *testing.T) {
 	p := &gmailplugin.Plugin{}
-	if got := p.Name(); got != "gmail" {
-		t.Errorf("Name: got %q, want \"gmail\"", got)
-	}
-}
+	p.SetGuideData([]byte(`{"sections":[]}`))
 
-func TestPlugin_Description(t *testing.T) {
-	p := &gmailplugin.Plugin{}
-	if got := p.Description(); got == "" {
+	metadata := p.Metadata()
+	if metadata.Name != "gmail" {
+		t.Errorf("Name: got %q, want \"gmail\"", metadata.Name)
+	}
+	if metadata.Description == "" {
 		t.Error("Description: got empty string, want non-empty")
 	}
-}
-
-func TestPlugin_RequiredScopes(t *testing.T) {
-	p := &gmailplugin.Plugin{}
-	scopes := p.RequiredScopes()
+	if metadata.Auth.Type != plugins.AuthTypeOAuth {
+		t.Errorf("Auth.Type: got %q, want %q", metadata.Auth.Type, plugins.AuthTypeOAuth)
+	}
+	if !metadata.Auth.RequiresCredentialsUpload {
+		t.Error("RequiresCredentialsUpload: got false, want true")
+	}
 
 	want := []string{
 		gmailapi.GmailReadonlyScope,
 	}
 
+	scopes := metadata.Auth.RequiredScopes
 	if len(scopes) != len(want) {
 		t.Fatalf("RequiredScopes: got %d scopes, want %d — got %v", len(scopes), len(want), scopes)
 	}
@@ -44,6 +46,12 @@ func TestPlugin_RequiredScopes(t *testing.T) {
 		if s != want[i] {
 			t.Errorf("scope[%d]: got %q, want %q", i, s, want[i])
 		}
+	}
+	if len(metadata.ConfigSchema) != 0 {
+		t.Errorf("ConfigSchema: got %v, want empty", metadata.ConfigSchema)
+	}
+	if len(metadata.SetupGuide) == 0 {
+		t.Error("SetupGuide: got empty, want guide data")
 	}
 }
 
@@ -53,7 +61,10 @@ func TestPlugin_NewReader_NilHTTPClient(t *testing.T) {
 		ScanInterval: 60,
 	}
 
-	_, err := p.NewReader(nil, cfg, nil, nil, nil, nil, testLogger())
+	_, err := p.NewReader(plugins.ReaderInput{
+		AppConfig: cfg,
+		Logger:    testLogger(),
+	})
 	if err == nil {
 		t.Error("expected error with nil http client, got nil")
 	}

--- a/backend/pkg/plugins/readers/thunderbird/plugin.go
+++ b/backend/pkg/plugins/readers/thunderbird/plugin.go
@@ -2,15 +2,13 @@
 package thunderbird
 
 import (
-	"log/slog"
-	"net/http"
+	"encoding/json"
 	"time"
 
 	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
 	tbreader "github.com/ArionMiles/expensor/backend/pkg/reader/thunderbird"
-	"github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
 // Plugin implements the ReaderPlugin interface for Thunderbird.
@@ -22,23 +20,20 @@ type Plugin struct {
 // the centralized content/readers/thunderbird/guide.json via go:embed.
 func (p *Plugin) SetGuideData(data []byte) { p.guideData = data }
 
-// Name returns the plugin name.
-func (p *Plugin) Name() string { return "thunderbird" }
-
-// Description returns a human-readable description.
-func (p *Plugin) Description() string {
-	return "Read expense transactions from Thunderbird mailbox files (MBOX format)"
+// Metadata returns catalog metadata for the Thunderbird reader plugin.
+func (p *Plugin) Metadata() plugins.ReaderMetadata {
+	return plugins.ReaderMetadata{
+		Name:        "thunderbird",
+		Description: "Read expense transactions from Thunderbird mailbox files (MBOX format)",
+		Auth: plugins.AuthSpec{
+			Type:                      plugins.AuthTypeConfig,
+			RequiredScopes:            []string{},
+			RequiresCredentialsUpload: false,
+		},
+		ConfigSchema: p.ConfigSchema(),
+		SetupGuide:   p.guideData,
+	}
 }
-
-// RequiredScopes returns the OAuth scopes needed by this plugin.
-// Thunderbird reader doesn't need OAuth as it reads local files.
-func (p *Plugin) RequiredScopes() []string { return []string{} }
-
-// AuthType returns the authentication type for Thunderbird (config-only, no OAuth).
-func (p *Plugin) AuthType() plugins.AuthType { return plugins.AuthTypeConfig }
-
-// RequiresCredentialsUpload reports that Thunderbird does not need credentials upload.
-func (p *Plugin) RequiresCredentialsUpload() bool { return false }
 
 // ConfigSchema returns the fields required to configure Thunderbird.
 func (p *Plugin) ConfigSchema() []plugins.ConfigField {
@@ -80,22 +75,29 @@ func (p *Plugin) ApplyConfig(cfg *config.Config, raw map[string]any) {
 }
 
 // NewReader creates a new Thunderbird reader instance.
-// The httpClient parameter is unused for Thunderbird (no OAuth needed).
-func (p *Plugin) NewReader( //nolint:revive // interface method; argument count dictated by ReaderPlugin
-	httpClient *http.Client, cfg *config.Config, rules []api.Rule,
-	resolver api.CategoryResolver, stateManager *state.Manager, diagnosticSink api.DiagnosticSink, logger *slog.Logger,
-) (api.Reader, error) {
+func (p *Plugin) NewReader(input plugins.ReaderInput) (api.Reader, error) {
+	cfg := config.Config{}
+	if input.AppConfig != nil {
+		cfg = *input.AppConfig
+	}
+	if len(input.ReaderConfig) > 0 {
+		var raw map[string]any
+		if err := json.Unmarshal(input.ReaderConfig, &raw); err == nil {
+			p.ApplyConfig(&cfg, raw)
+		}
+	}
+
 	readerCfg := tbreader.Config{
 		ProfilePath:    cfg.Thunderbird.ProfilePath,
 		Mailboxes:      cfg.Thunderbird.GetMailboxes(),
-		Rules:          rules,
-		Resolver:       resolver,
-		State:          stateManager,
+		Rules:          input.Rules,
+		Resolver:       input.Resolver,
+		State:          input.StateManager,
 		Interval:       time.Duration(cfg.ScanInterval) * time.Second,
 		LastScanAt:     cfg.LastScanAt,
 		ForceFullScan:  cfg.ForceFullScan,
 		OnCheckpoint:   cfg.OnCheckpoint,
-		DiagnosticSink: diagnosticSink,
+		DiagnosticSink: input.DiagnosticSink,
 	}
-	return tbreader.New(readerCfg, logger)
+	return tbreader.New(readerCfg, input.Logger)
 }

--- a/backend/pkg/plugins/readers/thunderbird/plugin_test.go
+++ b/backend/pkg/plugins/readers/thunderbird/plugin_test.go
@@ -8,31 +8,34 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
 	"github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
-func TestPlugin_Name(t *testing.T) {
+func TestPlugin_Metadata(t *testing.T) {
 	plugin := &Plugin{}
-	if got := plugin.Name(); got != "thunderbird" {
-		t.Errorf("Name() = %q, want %q", got, "thunderbird")
-	}
-}
+	plugin.SetGuideData([]byte(`{"sections":[]}`))
 
-func TestPlugin_Description(t *testing.T) {
-	plugin := &Plugin{}
-	desc := plugin.Description()
-	if desc == "" {
-		t.Error("Description() should not be empty")
+	metadata := plugin.Metadata()
+	if metadata.Name != "thunderbird" {
+		t.Errorf("Name = %q, want %q", metadata.Name, "thunderbird")
 	}
-}
-
-func TestPlugin_RequiredScopes(t *testing.T) {
-	plugin := &Plugin{}
-	scopes := plugin.RequiredScopes()
-	if len(scopes) != 0 {
-		t.Errorf("RequiredScopes() should be empty for Thunderbird, got %v", scopes)
+	if metadata.Description == "" {
+		t.Error("Description should not be empty")
+	}
+	if metadata.Auth.Type != plugins.AuthTypeConfig {
+		t.Errorf("Auth.Type = %q, want %q", metadata.Auth.Type, plugins.AuthTypeConfig)
+	}
+	if metadata.Auth.RequiresCredentialsUpload {
+		t.Error("RequiresCredentialsUpload = true, want false")
+	}
+	if len(metadata.ConfigSchema) == 0 {
+		t.Error("ConfigSchema should not be empty")
+	}
+	if len(metadata.SetupGuide) == 0 {
+		t.Error("SetupGuide should not be empty after SetGuideData")
 	}
 }
 
@@ -82,7 +85,12 @@ func TestPlugin_NewReader(t *testing.T) {
 	plugin := &Plugin{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	reader, err := plugin.NewReader(nil, cfg, rules, nil, stateManager, nil, logger)
+	reader, err := plugin.NewReader(plugins.ReaderInput{
+		AppConfig:    cfg,
+		Rules:        rules,
+		StateManager: stateManager,
+		Logger:       logger,
+	})
 	if err != nil {
 		t.Fatalf("NewReader() failed: %v", err)
 	}
@@ -114,7 +122,12 @@ func TestPlugin_NewReader_MissingMailbox(t *testing.T) {
 	plugin := &Plugin{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	_, err = plugin.NewReader(nil, cfg, []api.Rule{}, nil, stateManager, nil, logger)
+	_, err = plugin.NewReader(plugins.ReaderInput{
+		AppConfig:    cfg,
+		Rules:        []api.Rule{},
+		StateManager: stateManager,
+		Logger:       logger,
+	})
 	if err == nil {
 		t.Error("expected error for missing mailbox, got nil")
 	}
@@ -152,11 +165,49 @@ func TestPlugin_NewReader_DefaultInterval(t *testing.T) {
 	plugin := &Plugin{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	reader, err := plugin.NewReader(nil, cfg, []api.Rule{}, nil, stateManager, nil, logger)
+	reader, err := plugin.NewReader(plugins.ReaderInput{
+		AppConfig:    cfg,
+		Rules:        []api.Rule{},
+		StateManager: stateManager,
+		Logger:       logger,
+	})
 	if err != nil {
 		t.Fatalf("NewReader() failed: %v", err)
 	}
 
+	if reader == nil {
+		t.Error("NewReader() returned nil reader")
+	}
+}
+
+func TestPlugin_NewReader_UsesPersistedReaderConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	mailDir := filepath.Join(tmpDir, "Mail", "Local Folders")
+	if err := os.MkdirAll(mailDir, 0o755); err != nil {
+		t.Fatalf("failed to create mail dir: %v", err)
+	}
+	for _, mailbox := range []string{"Inbox", "Sent"} {
+		if err := os.WriteFile(filepath.Join(mailDir, mailbox), []byte(""), 0o600); err != nil {
+			t.Fatalf("failed to create %s: %v", mailbox, err)
+		}
+	}
+
+	stateFile := filepath.Join(tmpDir, "state.json")
+	stateManager, err := state.New(stateFile, slog.Default())
+	if err != nil {
+		t.Fatalf("failed to create state manager: %v", err)
+	}
+
+	plugin := &Plugin{}
+	reader, err := plugin.NewReader(plugins.ReaderInput{
+		AppConfig:    &config.Config{},
+		ReaderConfig: []byte(`{"config":{"profilePath":"` + tmpDir + `","mailboxes":"Inbox,Sent"}}`),
+		StateManager: stateManager,
+		Logger:       slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+	})
+	if err != nil {
+		t.Fatalf("NewReader() failed: %v", err)
+	}
 	if reader == nil {
 		t.Error("NewReader() returned nil reader")
 	}

--- a/backend/pkg/plugins/writers/postgres/plugin.go
+++ b/backend/pkg/plugins/writers/postgres/plugin.go
@@ -3,9 +3,9 @@ package postgres
 
 import (
 	"log/slog"
-	"net/http"
 	"time"
 
+	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
 	pgwriter "github.com/ArionMiles/expensor/backend/pkg/writer/postgres"
@@ -14,25 +14,25 @@ import (
 // Plugin implements the WriterPlugin interface for PostgreSQL.
 type Plugin struct{}
 
-// Name returns the plugin name.
-func (p *Plugin) Name() string {
-	return "postgres"
-}
-
-// Description returns a human-readable description.
-func (p *Plugin) Description() string {
-	return "Write expense transactions to PostgreSQL database with multi-currency support"
-}
-
-// RequiredScopes returns the OAuth scopes needed by this plugin.
-// PostgreSQL writer doesn't require OAuth scopes.
-func (p *Plugin) RequiredScopes() []string {
-	return []string{}
+// Metadata returns catalog metadata for the PostgreSQL writer plugin.
+func (p *Plugin) Metadata() plugins.WriterMetadata {
+	return plugins.WriterMetadata{
+		Name:           "postgres",
+		Description:    "Write expense transactions to PostgreSQL database with multi-currency support",
+		RequiredScopes: []string{},
+	}
 }
 
 // NewWriter creates a new PostgreSQL writer instance.
-// Note: httpClient is ignored as PostgreSQL doesn't need OAuth.
-func (p *Plugin) NewWriter(httpClient *http.Client, cfg *config.Config, logger *slog.Logger) (api.Writer, error) {
+func (p *Plugin) NewWriter(input plugins.WriterInput) (api.Writer, error) {
+	cfg := input.AppConfig
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	logger := input.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
 	logger.Debug("postgres writer config",
 		"host", cfg.Postgres.Host,
 		"port", cfg.Postgres.Port,

--- a/backend/pkg/plugins/writers/postgres/plugin_test.go
+++ b/backend/pkg/plugins/writers/postgres/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
 	postgresplugin "github.com/ArionMiles/expensor/backend/pkg/plugins/writers/postgres"
 )
@@ -13,25 +14,17 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
-func TestPlugin_Name(t *testing.T) {
+func TestPlugin_Metadata(t *testing.T) {
 	p := &postgresplugin.Plugin{}
-	if got := p.Name(); got != "postgres" {
-		t.Errorf("Name: got %q, want \"postgres\"", got)
+	metadata := p.Metadata()
+	if metadata.Name != "postgres" {
+		t.Errorf("Name: got %q, want \"postgres\"", metadata.Name)
 	}
-}
-
-func TestPlugin_Description(t *testing.T) {
-	p := &postgresplugin.Plugin{}
-	if got := p.Description(); got == "" {
+	if metadata.Description == "" {
 		t.Error("Description: got empty string, want non-empty")
 	}
-}
-
-func TestPlugin_RequiredScopes(t *testing.T) {
-	p := &postgresplugin.Plugin{}
-	scopes := p.RequiredScopes()
-	if len(scopes) != 0 {
-		t.Errorf("RequiredScopes: got %v, want empty slice", scopes)
+	if len(metadata.RequiredScopes) != 0 {
+		t.Errorf("RequiredScopes: got %v, want empty slice", metadata.RequiredScopes)
 	}
 }
 
@@ -51,7 +44,10 @@ func TestPlugin_NewWriter_ConnectionFailure(t *testing.T) {
 		},
 	}
 
-	_, err := p.NewWriter(nil, cfg, testLogger())
+	_, err := p.NewWriter(plugins.WriterInput{
+		AppConfig: cfg,
+		Logger:    testLogger(),
+	})
 	if err == nil {
 		t.Error("expected error connecting to nonexistent host, got nil")
 	}

--- a/docs/superpowers/plans/2026-05-25-plugin-registry-catalog.md
+++ b/docs/superpowers/plans/2026-05-25-plugin-registry-catalog.md
@@ -1,0 +1,757 @@
+# Plugin Registry Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `internal/plugins.Registry` a catalog-only type while moving reader/writer assembly and persisted reader config handling to daemon wiring.
+
+**Architecture:** Plugins expose required metadata through explicit metadata structs and construct readers/writers from input structs instead of long flattened argument lists. The registry only registers, retrieves, lists, and combines plugin scope metadata; daemon runtime code resolves plugins and calls constructors directly. API handlers keep the same response shape but read all reader metadata, including setup guides, from `ReaderMetadata`.
+
+**Tech Stack:** Go 1.26, `log/slog`, `encoding/json`, existing `task` backend test targets, existing Gmail/Thunderbird/Postgres plugin packages.
+
+---
+
+## Scope Check
+
+This plan implements implementation-order item 5 from `docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md`: plugin metadata and construction boundary cleanup. It intentionally does not split `internal/api/handlers.go`, change processed-message state contexts, move Gmail query construction out of `pkg/api`, or add new observability spans. The result should be independently testable with backend unit tests and the prod linter.
+
+## File Structure
+
+- `backend/internal/plugins/registry.go`: keep plugin catalog and shared plugin-facing types; add metadata/input structs; remove optional `GuideProvider`, optional `ConfigApplier`, and `Registry.CreateReader/CreateWriter`.
+- `backend/internal/plugins/registry_test.go`: change tests from factory behavior to catalog-only behavior, metadata exposure, and input struct constructor behavior through test plugins.
+- `backend/internal/daemon/runner.go`: own daemon assembly by retrieving plugins from the registry, loading persisted reader config, and calling `plugin.NewReader(plugins.ReaderInput{...})` / `plugin.NewWriter(plugins.WriterInput{...})`.
+- `backend/internal/daemon/runner_test.go`: update mock plugins to metadata/input structs and assert persisted reader config is passed to reader construction without optional config mutation.
+- `backend/internal/api/handlers.go`: read reader/writer listing, auth, readiness, credentials, and guide behavior from metadata.
+- `backend/internal/api/handlers_test.go`: update test plugins; add guide success coverage now that guides are required metadata rather than an optional interface.
+- `backend/pkg/plugins/readers/gmail/plugin.go`: return `ReaderMetadata`; accept `ReaderInput`.
+- `backend/pkg/plugins/readers/gmail/plugin_test.go`: update constructor tests to `ReaderInput`.
+- `backend/pkg/plugins/readers/thunderbird/plugin.go`: return `ReaderMetadata`; accept `ReaderInput`; decode persisted `ReaderConfig` directly into Thunderbird reader config.
+- `backend/pkg/plugins/readers/thunderbird/plugin_test.go`: add persisted config decode tests and update constructor tests.
+- `backend/pkg/plugins/writers/postgres/plugin.go`: return `WriterMetadata`; accept `WriterInput`.
+- `backend/pkg/plugins/writers/postgres/plugin_test.go`: update constructor tests.
+- `backend/cmd/server/main.go`: no behavior change expected; compile-time updates only for metadata/constructor API if needed.
+- `docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md`: mark plugin registry cleanup complete after implementation and verification.
+
+---
+
+### Task 1: Introduce Metadata And Input Struct API
+
+**Files:**
+- Modify: `backend/internal/plugins/registry.go`
+- Modify: `backend/internal/plugins/registry_test.go`
+
+- [ ] **Step 1: Write failing tests for catalog-only registry behavior**
+
+Update the test mock types in `backend/internal/plugins/registry_test.go` so readers and writers expose metadata and input-struct constructors:
+
+```go
+type mockReaderPlugin struct {
+	name        string
+	description string
+	scopes      []string
+	guide       []byte
+	reader      api.Reader
+	err         error
+	input       ReaderInput
+}
+
+func (m *mockReaderPlugin) Metadata() ReaderMetadata {
+	return ReaderMetadata{
+		Name:        m.name,
+		Description: m.description,
+		Auth: AuthSpec{
+			Type:                      AuthTypeOAuth,
+			RequiredScopes:            m.scopes,
+			RequiresCredentialsUpload: false,
+		},
+		ConfigSchema: nil,
+		SetupGuide:   m.guide,
+	}
+}
+
+func (m *mockReaderPlugin) NewReader(input ReaderInput) (api.Reader, error) {
+	m.input = input
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.reader, nil
+}
+
+type mockWriterPlugin struct {
+	name        string
+	description string
+	scopes      []string
+	writer      api.Writer
+	err         error
+	input       WriterInput
+}
+
+func (m *mockWriterPlugin) Metadata() WriterMetadata {
+	return WriterMetadata{Name: m.name, Description: m.description, RequiredScopes: m.scopes}
+}
+
+func (m *mockWriterPlugin) NewWriter(input WriterInput) (api.Writer, error) {
+	m.input = input
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.writer, nil
+}
+```
+
+Replace assertions that call `Name()`, `Description()`, and `RequiredScopes()` with `Metadata()` assertions. Add a test that registry no longer exposes factory helpers:
+
+```go
+func TestRegistryIsCatalogOnly(t *testing.T) {
+	registry := NewRegistry()
+	reader := &mockReaderPlugin{name: "test-reader", reader: &mockReader{}}
+	writer := &mockWriterPlugin{name: "test-writer", writer: &mockWriter{}}
+
+	if err := registry.RegisterReader(reader); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	if err := registry.RegisterWriter(writer); err != nil {
+		t.Fatalf("RegisterWriter() error = %v", err)
+	}
+
+	gotReader, err := registry.GetReader("test-reader")
+	if err != nil {
+		t.Fatalf("GetReader() error = %v", err)
+	}
+	if gotReader.Metadata().Name != "test-reader" {
+		t.Fatalf("reader name = %q, want test-reader", gotReader.Metadata().Name)
+	}
+
+	gotWriter, err := registry.GetWriter("test-writer")
+	if err != nil {
+		t.Fatalf("GetWriter() error = %v", err)
+	}
+	if gotWriter.Metadata().Name != "test-writer" {
+		t.Fatalf("writer name = %q, want test-writer", gotWriter.Metadata().Name)
+	}
+}
+```
+
+Delete `TestCreateReader`, `TestCreateReader_NotFound`, `TestCreateWriter`, and `TestCreateWriter_NotFound`; those behaviors will move to daemon tests.
+
+- [ ] **Step 2: Run registry tests to verify red**
+
+Run:
+
+```bash
+task test:be -- ./internal/plugins
+```
+
+Expected: FAIL because `ReaderMetadata`, `WriterMetadata`, `ReaderInput`, `WriterInput`, and `Metadata()` do not exist yet.
+
+- [ ] **Step 3: Implement metadata and input structs**
+
+Replace the plugin interfaces and remove optional interfaces in `backend/internal/plugins/registry.go`:
+
+```go
+type AuthSpec struct {
+	Type                      AuthType `json:"type"`
+	RequiredScopes            []string `json:"required_scopes"`
+	RequiresCredentialsUpload bool     `json:"requires_credentials_upload"`
+}
+
+type ReaderMetadata struct {
+	Name         string          `json:"name"`
+	Description  string          `json:"description"`
+	Auth         AuthSpec        `json:"auth"`
+	ConfigSchema []ConfigField   `json:"config_schema"`
+	SetupGuide   json.RawMessage `json:"setup_guide,omitempty"`
+}
+
+type WriterMetadata struct {
+	Name           string   `json:"name"`
+	Description    string   `json:"description"`
+	RequiredScopes []string `json:"required_scopes"`
+}
+
+type ReaderInput struct {
+	HTTPClient     *http.Client
+	AppConfig      *config.Config
+	ReaderConfig   json.RawMessage
+	Rules          []api.Rule
+	Resolver       api.CategoryResolver
+	StateManager   *state.Manager
+	DiagnosticSink api.DiagnosticSink
+	Logger         *slog.Logger
+}
+
+type WriterInput struct {
+	HTTPClient *http.Client
+	AppConfig  *config.Config
+	Logger     *slog.Logger
+}
+
+type ReaderPlugin interface {
+	Metadata() ReaderMetadata
+	NewReader(input ReaderInput) (api.Reader, error)
+}
+
+type WriterPlugin interface {
+	Metadata() WriterMetadata
+	NewWriter(input WriterInput) (api.Writer, error)
+}
+```
+
+Update registry methods to use `plugin.Metadata().Name`, update `GetAllScopes` to read `reader.Metadata().Auth.RequiredScopes` and `writer.Metadata().RequiredScopes`, and remove `CreateReader` / `CreateWriter`.
+
+- [ ] **Step 4: Run registry tests to verify green**
+
+Run:
+
+```bash
+task test:be -- ./internal/plugins
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit registry API change**
+
+Run:
+
+```bash
+git add backend/internal/plugins/registry.go backend/internal/plugins/registry_test.go
+git commit --no-gpg-sign -m "Refactor plugin registry as a catalog"
+```
+
+---
+
+### Task 2: Move Reader And Writer Assembly Into Daemon Runner
+
+**Files:**
+- Modify: `backend/internal/daemon/runner.go`
+- Modify: `backend/internal/daemon/runner_test.go`
+
+- [ ] **Step 1: Write failing daemon tests for direct plugin construction**
+
+Update daemon mock plugins to implement `Metadata()` and input-struct constructors. Add a test that persisted reader config is passed into `ReaderInput.ReaderConfig`:
+
+```go
+func TestRun_PassesPersistedReaderConfigToPlugin(t *testing.T) {
+	reader := &mockReader{done: make(chan struct{})}
+	writer := &mockWriter{done: make(chan struct{})}
+	readerPlugin := &mockReaderPlugin{name: "test-reader", reader: reader}
+	writerPlugin := &mockWriterPlugin{name: "test-writer", writer: writer}
+	registry := plugins.NewRegistry()
+	if err := registry.RegisterReader(readerPlugin); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	if err := registry.RegisterWriter(writerPlugin); err != nil {
+		t.Fatalf("RegisterWriter() error = %v", err)
+	}
+
+	runtimeStore := &mockRuntimeStore{
+		readerConfig: json.RawMessage(`{"config":{"profilePath":"/tmp/profile","mailboxes":"Inbox"}}`),
+		hasConfig:    true,
+	}
+	runner := New(registry, &http.Client{}, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reader.onRead = func() { cancel() }
+	err := runner.Run(ctx, RunConfig{
+		ReaderName:   "test-reader",
+		WriterName:   "test-writer",
+		Config:       &config.Config{},
+		RuntimeStore: runtimeStore,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if string(readerPlugin.input.ReaderConfig) != string(runtimeStore.readerConfig) {
+		t.Fatalf("ReaderConfig = %s, want %s", readerPlugin.input.ReaderConfig, runtimeStore.readerConfig)
+	}
+}
+```
+
+Update `TestRun_CreateReaderError` and `TestRun_CreateWriterError` to expect errors from direct `plugin.NewReader` and `plugin.NewWriter` calls rather than `Registry.CreateReader/CreateWriter`.
+
+- [ ] **Step 2: Run daemon tests to verify red**
+
+Run:
+
+```bash
+task test:be -- ./internal/daemon
+```
+
+Expected: FAIL because daemon still calls removed registry factory helpers and still uses `ConfigApplier`.
+
+- [ ] **Step 3: Implement daemon-owned assembly**
+
+In `backend/internal/daemon/runner.go`, remove `persistedReaderConfigInput` and `applyPersistedReaderConfig`. Add:
+
+```go
+func (r *Runner) loadReaderConfig(ctx context.Context, readerName string, store ReaderRuntimeStore) json.RawMessage {
+	if store == nil {
+		return nil
+	}
+	data, ok, err := store.GetReaderConfig(ctx, readerName)
+	if err != nil {
+		r.logger.Warn("failed to read persisted reader config", "reader", readerName, "error", err)
+		return nil
+	}
+	if !ok {
+		return nil
+	}
+	return data
+}
+```
+
+Then replace registry factory calls in `Run`:
+
+```go
+readerPlugin, err := r.registry.GetReader(runCfg.ReaderName)
+if err != nil {
+	return fmt.Errorf("creating reader: %w", err)
+}
+reader, err := readerPlugin.NewReader(plugins.ReaderInput{
+	HTTPClient:     r.httpClient,
+	AppConfig:      cfg,
+	ReaderConfig:   r.loadReaderConfig(ctx, runCfg.ReaderName, runCfg.RuntimeStore),
+	Rules:          runCfg.Rules,
+	Resolver:       runCfg.Resolver,
+	StateManager:   runCfg.StateManager,
+	DiagnosticSink: runCfg.DiagnosticSink,
+	Logger:         r.logger.With("component", "reader", "plugin", runCfg.ReaderName),
+})
+if err != nil {
+	return fmt.Errorf("creating reader: %w", err)
+}
+
+writerPlugin, err := r.registry.GetWriter(runCfg.WriterName)
+if err != nil {
+	return fmt.Errorf("creating writer: %w", err)
+}
+writer, err := writerPlugin.NewWriter(plugins.WriterInput{
+	HTTPClient: r.httpClient,
+	AppConfig:  cfg,
+	Logger:     r.logger.With("component", "writer", "plugin", runCfg.WriterName),
+})
+if err != nil {
+	return fmt.Errorf("creating writer: %w", err)
+}
+```
+
+- [ ] **Step 4: Run daemon tests to verify green**
+
+Run:
+
+```bash
+task test:be -- ./internal/daemon
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit daemon assembly change**
+
+Run:
+
+```bash
+git add backend/internal/daemon/runner.go backend/internal/daemon/runner_test.go
+git commit --no-gpg-sign -m "Move plugin assembly into daemon runner"
+```
+
+---
+
+### Task 3: Update API Handlers To Use Required Metadata
+
+**Files:**
+- Modify: `backend/internal/api/handlers.go`
+- Modify: `backend/internal/api/handlers_test.go`
+
+- [ ] **Step 1: Write failing API metadata tests**
+
+Update `testReaderPlugin` and `testWriterPlugin` in `backend/internal/api/handlers_test.go` to implement metadata and input-struct constructors. Add a successful guide test:
+
+```go
+func TestHandleGetReaderGuide_ReturnsMetadataGuide(t *testing.T) {
+	h := newTestHandlers()
+	registry := plugins.NewRegistry()
+	guide := json.RawMessage(`{"sections":[{"title":"Setup","steps":[{"text":"Do the setup"}]}]}`)
+	if err := registry.RegisterReader(&testReaderPlugin{name: "guided", authType: plugins.AuthTypeConfig, guide: guide}); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	h.registry = registry
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/guided/guide", nil)
+	req.SetPathValue("name", "guided")
+	rr := httptest.NewRecorder()
+
+	h.HandleGetReaderGuide(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Do the setup") {
+		t.Fatalf("body = %s, want setup guide", rr.Body.String())
+	}
+}
+```
+
+Keep `TestHandleGetReaderGuide_NoGuide_Returns404`, but make it use a reader with empty `Metadata().SetupGuide`.
+
+- [ ] **Step 2: Run API tests to verify red**
+
+Run:
+
+```bash
+task test:be -- ./internal/api
+```
+
+Expected: FAIL because handlers still call methods removed from plugin interfaces and still type-assert `GuideProvider`.
+
+- [ ] **Step 3: Update handlers to read metadata**
+
+In `backend/internal/api/handlers.go`, replace direct method calls as follows:
+
+```go
+meta := p.Metadata()
+ReaderInfo{
+	Name:                      meta.Name,
+	Description:               meta.Description,
+	AuthType:                  meta.Auth.Type,
+	RequiresCredentialsUpload: meta.Auth.RequiresCredentialsUpload,
+	ConfigSchema:              meta.ConfigSchema,
+}
+```
+
+Use `plugin.Metadata().Auth.Type`, `plugin.Metadata().Auth.RequiredScopes`, `plugin.Metadata().Auth.RequiresCredentialsUpload`, and `plugin.Metadata().ConfigSchema` in credentials, OAuth, auth status, reader status, and setup guide handlers. Replace the guide handler body with:
+
+```go
+guideData := plugin.Metadata().SetupGuide
+if len(guideData) == 0 {
+	writeError(w, http.StatusNotFound, "no setup guide available for this reader")
+	return
+}
+var guide plugins.ReaderGuide
+if err := json.Unmarshal(guideData, &guide); err != nil {
+	h.logger.Error("parsing reader guide", "reader", name, "error", err)
+	writeError(w, http.StatusInternalServerError, "failed to parse reader guide")
+	return
+}
+writeJSON(w, http.StatusOK, guide)
+```
+
+- [ ] **Step 4: Run API tests to verify green**
+
+Run:
+
+```bash
+task test:be -- ./internal/api
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit API metadata usage**
+
+Run:
+
+```bash
+git add backend/internal/api/handlers.go backend/internal/api/handlers_test.go
+git commit --no-gpg-sign -m "Read plugin metadata in API handlers"
+```
+
+---
+
+### Task 4: Update Concrete Reader And Writer Plugins
+
+**Files:**
+- Modify: `backend/pkg/plugins/readers/gmail/plugin.go`
+- Modify: `backend/pkg/plugins/readers/gmail/plugin_test.go`
+- Modify: `backend/pkg/plugins/readers/thunderbird/plugin.go`
+- Modify: `backend/pkg/plugins/readers/thunderbird/plugin_test.go`
+- Modify: `backend/pkg/plugins/writers/postgres/plugin.go`
+- Modify: `backend/pkg/plugins/writers/postgres/plugin_test.go`
+- Modify: `backend/cmd/server/main.go`
+
+- [ ] **Step 1: Write failing concrete plugin tests**
+
+Update Gmail tests to assert metadata:
+
+```go
+func TestPlugin_Metadata(t *testing.T) {
+	p := &gmailplugin.Plugin{}
+	p.SetGuideData([]byte(`{"sections":[]}`))
+
+	meta := p.Metadata()
+
+	if meta.Name != "gmail" {
+		t.Fatalf("Name = %q, want gmail", meta.Name)
+	}
+	if meta.Auth.Type != plugins.AuthTypeOAuth {
+		t.Fatalf("Auth.Type = %q, want oauth", meta.Auth.Type)
+	}
+	if !meta.Auth.RequiresCredentialsUpload {
+		t.Fatal("RequiresCredentialsUpload = false, want true")
+	}
+	if len(meta.Auth.RequiredScopes) == 0 {
+		t.Fatal("RequiredScopes is empty")
+	}
+	if len(meta.SetupGuide) == 0 {
+		t.Fatal("SetupGuide is empty")
+	}
+}
+```
+
+Update Thunderbird tests to assert persisted reader config is decoded by `NewReader`:
+
+```go
+func TestPlugin_NewReader_UsesPersistedReaderConfig(t *testing.T) {
+	plugin := &thunderbirdplugin.Plugin{}
+	logger := testLogger()
+	stateManager, err := state.New(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatalf("state.New() error = %v", err)
+	}
+
+	reader, err := plugin.NewReader(plugins.ReaderInput{
+		AppConfig:    &config.Config{ScanInterval: 30},
+		ReaderConfig: json.RawMessage(`{"config":{"profilePath":"/tmp/profile","mailboxes":"Inbox,Sent"}}`),
+		StateManager: stateManager,
+		Logger:       logger,
+	})
+	if err != nil {
+		t.Fatalf("NewReader() error = %v", err)
+	}
+	if reader == nil {
+		t.Fatal("NewReader() returned nil reader")
+	}
+}
+```
+
+Update Postgres tests to use `WriterInput`.
+
+- [ ] **Step 2: Run plugin package tests to verify red**
+
+Run:
+
+```bash
+task test:be -- ./pkg/plugins/readers/gmail ./pkg/plugins/readers/thunderbird ./pkg/plugins/writers/postgres ./cmd/server
+```
+
+Expected: FAIL because concrete plugins still expose old methods and constructors.
+
+- [ ] **Step 3: Implement concrete metadata and input constructors**
+
+For Gmail, implement:
+
+```go
+func (p *Plugin) Metadata() plugins.ReaderMetadata {
+	return plugins.ReaderMetadata{
+		Name:        "gmail",
+		Description: "Read expense transactions from Gmail messages",
+		Auth: plugins.AuthSpec{
+			Type:                      plugins.AuthTypeOAuth,
+			RequiredScopes:            []string{gmailapi.GmailReadonlyScope},
+			RequiresCredentialsUpload: true,
+		},
+		ConfigSchema: []plugins.ConfigField{},
+		SetupGuide:   p.guideData,
+	}
+}
+
+func (p *Plugin) NewReader(input plugins.ReaderInput) (api.Reader, error) {
+	cfg := input.AppConfig
+	interval := time.Duration(cfg.ScanInterval) * time.Second
+	if interval == 0 {
+		interval = 60 * time.Second
+	}
+	readerCfg := gmailreader.Config{
+		Rules:          input.Rules,
+		Resolver:       input.Resolver,
+		Interval:       interval,
+		State:          input.StateManager,
+		LookbackDays:   cfg.LookbackDays,
+		LastScanAt:     cfg.LastScanAt,
+		ForceFullScan:  cfg.ForceFullScan,
+		OnCheckpoint:   cfg.OnCheckpoint,
+		DiagnosticSink: input.DiagnosticSink,
+	}
+	return gmailreader.New(input.HTTPClient, readerCfg, input.Logger)
+}
+```
+
+For Thunderbird, create a small private decoder:
+
+```go
+type persistedReaderConfig struct {
+	Config struct {
+		ProfilePath string `json:"profilePath"`
+		Mailboxes   string `json:"mailboxes"`
+	} `json:"config"`
+}
+
+func applyReaderConfig(cfg *config.Config, raw json.RawMessage) {
+	if len(raw) == 0 {
+		return
+	}
+	var persisted persistedReaderConfig
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		return
+	}
+	if persisted.Config.ProfilePath != "" {
+		cfg.Thunderbird.ProfilePath = persisted.Config.ProfilePath
+	}
+	if persisted.Config.Mailboxes != "" {
+		cfg.Thunderbird.Mailboxes = persisted.Config.Mailboxes
+	}
+}
+```
+
+Call `applyReaderConfig(cfg, input.ReaderConfig)` before building `tbreader.Config`.
+
+For Postgres, implement `Metadata() plugins.WriterMetadata` and change `NewWriter(input plugins.WriterInput)`.
+
+Update `registerPlugins` to log/register using `p.Metadata().Name`.
+
+- [ ] **Step 4: Run plugin package tests to verify green**
+
+Run:
+
+```bash
+task test:be -- ./pkg/plugins/readers/gmail ./pkg/plugins/readers/thunderbird ./pkg/plugins/writers/postgres ./cmd/server
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit concrete plugin migration**
+
+Run:
+
+```bash
+git add backend/pkg/plugins/readers/gmail backend/pkg/plugins/readers/thunderbird backend/pkg/plugins/writers/postgres backend/cmd/server/main.go
+git commit --no-gpg-sign -m "Migrate concrete plugins to metadata inputs"
+```
+
+---
+
+### Task 5: Remove Old Plugin Surface And Update Spec Status
+
+**Files:**
+- Modify: `backend/internal/plugins/registry.go`
+- Modify: `docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md`
+
+- [ ] **Step 1: Search for removed optional/factory APIs**
+
+Run:
+
+```bash
+rg -n "GuideProvider|ConfigApplier|CreateReader|CreateWriter|RequiredScopes\\(|RequiresCredentialsUpload\\(|ConfigSchema\\(|AuthType\\(|Description\\(|Name\\(\\)" backend
+```
+
+Expected: FAIL as a cleanup check if any old plugin-surface references remain outside comments that are being edited in this task.
+
+- [ ] **Step 2: Remove stale comments and update the spec status**
+
+In `backend/internal/plugins/registry.go`, ensure no comments mention optional guide/config interfaces or registry factory helpers.
+
+In `docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md`, update the program status table row:
+
+```markdown
+| Plugin registry cleanup | Complete | Registry is now catalog-only; reader/writer metadata is explicit; daemon wiring owns construction. |
+```
+
+Update the implementation order item:
+
+```markdown
+5. Refactor plugin metadata and construction boundary. **Complete.**
+```
+
+- [ ] **Step 3: Run cleanup search again**
+
+Run:
+
+```bash
+rg -n "GuideProvider|ConfigApplier|CreateReader|CreateWriter" backend docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit cleanup and status update**
+
+Run:
+
+```bash
+git add backend/internal/plugins/registry.go docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md
+git commit --no-gpg-sign -m "Document plugin registry cleanup completion"
+```
+
+---
+
+### Task 6: Format, Verify, And Final Review
+
+**Files:**
+- Modify: any files changed by formatting.
+
+- [ ] **Step 1: Format backend code**
+
+Run:
+
+```bash
+task fmt:be
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Run focused backend tests**
+
+Run:
+
+```bash
+task test:be -- ./internal/plugins ./internal/daemon ./internal/api ./pkg/plugins/readers/gmail ./pkg/plugins/readers/thunderbird ./pkg/plugins/writers/postgres ./cmd/server
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full backend tests**
+
+Run:
+
+```bash
+task test:be
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run strict backend lint**
+
+Run:
+
+```bash
+task lint:be:prod
+```
+
+Expected: PASS with `0 issues`.
+
+- [ ] **Step 5: Run OpenAPI drift check**
+
+Run:
+
+```bash
+task openapi:check
+```
+
+Expected: PASS. This should not change generated OpenAPI output because API behavior and annotations are unchanged.
+
+- [ ] **Step 6: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat main...HEAD
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only intended backend and spec files changed.
+
+---
+
+## Self-Review
+
+- Spec coverage: This plan covers plugin registry cleanup from the backend observability/code-health spec, including catalog-only registry, required setup guide metadata, constructor input structs, and removal of optional metadata/config interfaces. It intentionally leaves API handler decomposition, store ownership cleanup, processed-message state context cleanup, and Gmail query domain cleanup for later plans.
+- Placeholder scan: No `TBD`, `TODO`, or deferred implementation placeholders are present.
+- Type consistency: `ReaderMetadata`, `WriterMetadata`, `AuthSpec`, `ReaderInput`, and `WriterInput` are introduced in Task 1 and used consistently by daemon, API, and concrete plugin tasks.

--- a/docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md
+++ b/docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md
@@ -19,7 +19,7 @@ The work has two equal outcomes:
 | Slice | Status | Notes |
 |-------|--------|-------|
 | Observability package and store instrumentation | Complete | Implemented in `pr/backend-observability-code-health`; see `docs/superpowers/plans/2026-05-24-observability-store-instrumentation.md`. |
-| Plugin registry cleanup | Pending | Requires a separate implementation plan. |
+| Plugin registry cleanup | Complete | Registry is now catalog-only; reader/writer metadata is explicit; daemon wiring owns construction. |
 | API handler decomposition | Pending | Requires a separate implementation plan. |
 | Store package ownership cleanup beyond instrumentation | Pending | Remaining work includes read-model ownership and `store.go` model/helper split. |
 | Processed-message state context cleanup | Pending | Requires a separate implementation plan. |
@@ -41,7 +41,7 @@ The work has two equal outcomes:
 
 ### Plugin Registry Drift
 
-`backend/internal/plugins/registry.go` is both a plugin catalog and an application factory. `ReaderPlugin.NewReader` has a long flattened argument list with HTTP client, global config, rules, category resolver, processed-message state, diagnostic sink, and logger. `GuideProvider` and `ConfigApplier` were added as optional interfaces even though setup guides are required metadata and persisted config decoding is a core reader concern.
+`backend/internal/plugins/registry.go` previously mixed catalog lookup with application assembly. Reader construction passed HTTP client, global config, rules, category resolver, processed-message state, diagnostic sink, and logger as a flattened dependency list. Setup-guide and reader-config behavior were also scattered instead of living in explicit plugin metadata and construction inputs.
 
 This makes adding a new reader or search capability harder because every new concern is likely to become another optional interface or constructor argument.
 
@@ -171,7 +171,7 @@ Composition should happen at wiring boundaries. Concrete repositories should not
 
 ### Plugin Registry Cleanup
 
-Keep the registry as a catalog. It should register and return plugins by name; it should not hide application assembly behind `CreateReader` or `CreateWriter`.
+Keep the registry as a catalog. It should register and return plugins by name, while daemon/runtime wiring owns application assembly.
 
 Replace scattered metadata methods with explicit metadata structs:
 
@@ -191,7 +191,7 @@ type ReaderMetadata struct {
 }
 ```
 
-Reader plugins expose required metadata directly. `GuideProvider` should be removed because setup guides are required. `ConfigApplier` should be removed because reader-specific config should be decoded by the reader/plugin construction path instead of mutating global `config.Config`.
+Reader plugins expose required metadata directly. Setup guides are part of `ReaderMetadata`, and reader-specific config is decoded by the reader/plugin construction path instead of mutating global `config.Config`.
 
 Reader construction should use one input struct if kept on plugin types:
 
@@ -317,7 +317,7 @@ Run component or contract tests only for slices that touch store behavior, daemo
 2. Add OTel trace/metric setup and no-op/default behavior. **Complete.**
 3. Replace store inline `QueryInstrumentation` with interface decorators. **Complete.**
 4. Split store capability interfaces and clean up `store.go` ownership. **Partially complete for instrumentation boundaries; remaining ownership cleanup is deferred.**
-5. Refactor plugin metadata and construction boundary.
+5. Refactor plugin metadata and construction boundary. **Complete.**
 6. Split `internal/api/handlers.go` by resource without behavior changes.
 7. Make processed-message state context-aware.
 8. Move Gmail-specific rule query construction out of `pkg/api`.


### PR DESCRIPTION
## Description

Refactors the backend plugin registry so it is a catalog only. Reader and writer plugins now expose explicit metadata and input-struct constructors, while daemon runtime wiring owns plugin construction and persisted reader config handoff.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

N/A

## Changes Made

- Made `internal/plugins.Registry` catalog-only with explicit reader/writer metadata, input structs, validation, and no factory helpers.
- Moved reader/writer assembly into the daemon runner and passed persisted reader config to reader plugins as raw JSON.
- Migrated API handlers and Gmail/Thunderbird/Postgres plugins to metadata-driven behavior while preserving response shapes and existing plugin behavior.
- Updated backend docs, the implementation plan, and the backend observability/code-health spec to mark plugin registry cleanup complete.

## Testing

- [x] Unit tests pass (`task test:be`)
- [x] Linter passes (`task lint:be:prod` and `task lint:fe`)
- [ ] Manual testing completed
- [x] Added new tests (if applicable)

Additional checks run:

- [x] `task fmt:be`
- [x] `task lint:be:prod`
- [x] `task openapi:check`
- [x] `git diff --check`

Note: `task lint:fe` was not run because this PR does not touch frontend code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This implements the plugin registry cleanup leg of the backend observability/code-health spec. Remaining backend code-health legs are API handler decomposition, store ownership cleanup, processed-message state context cleanup, and provider-specific domain cleanup.
