### PR TITLE
Clean up API handler naming

### DIFF
--- a/api/openapi/expensor.openapi.yaml
+++ b/api/openapi/expensor.openapi.yaml
@@ -1,32 +1,23 @@
 basePath: /api
 definitions:
-  api.DaemonStatus:
-    properties:
-      last_error:
-        type: string
-      running:
-        type: boolean
-      started_at:
-        type: string
-    type: object
-  api.DocActiveReaderResponse:
+  api.ActiveReaderResponse:
     properties:
       reader:
         example: gmail
         type: string
     type: object
-  api.DocAppliedCountResponse:
+  api.AppliedCountResponse:
     properties:
       applied:
         type: integer
     type: object
-  api.DocApplyLabelRequest:
+  api.ApplyLabelRequest:
     properties:
       merchant_pattern:
         example: swiggy
         type: string
     type: object
-  api.DocBankColorResponse:
+  api.BankColorResponse:
     properties:
       color:
         example: '#2563eb'
@@ -38,19 +29,19 @@ definitions:
         example: HDFC Bank
         type: string
     type: object
-  api.DocBaseCurrencyRequest:
+  api.BaseCurrencyRequest:
     properties:
       base_currency:
         example: USD
         type: string
     type: object
-  api.DocBaseCurrencyResponse:
+  api.BaseCurrencyResponse:
     properties:
       base_currency:
         example: USD
         type: string
     type: object
-  api.DocBucketResponse:
+  api.BucketResponse:
     properties:
       description:
         example: Essential spending
@@ -61,7 +52,7 @@ definitions:
         example: Needs
         type: string
     type: object
-  api.DocCategoryResponse:
+  api.CategoryResponse:
     properties:
       description:
         example: Restaurants and groceries
@@ -72,7 +63,7 @@ definitions:
         example: Food
         type: string
     type: object
-  api.DocCreateBucketRequest:
+  api.CreateBucketRequest:
     properties:
       description:
         example: Essential spending
@@ -81,7 +72,7 @@ definitions:
         example: Needs
         type: string
     type: object
-  api.DocCreateCategoryRequest:
+  api.CreateCategoryRequest:
     properties:
       description:
         example: Restaurants and groceries
@@ -90,7 +81,7 @@ definitions:
         example: Food
         type: string
     type: object
-  api.DocCreateLabelRequest:
+  api.CreateLabelRequest:
     properties:
       color:
         example: '#f59e0b'
@@ -99,19 +90,28 @@ definitions:
         example: food
         type: string
     type: object
-  api.DocDaemonReaderRequest:
+  api.DaemonReaderRequest:
     properties:
       reader:
         example: gmail
         type: string
     type: object
-  api.DocErrorResponse:
+  api.DaemonStatus:
+    properties:
+      last_error:
+        type: string
+      running:
+        type: boolean
+      started_at:
+        type: string
+    type: object
+  api.ErrorResponse:
     properties:
       error:
         example: database not connected
         type: string
     type: object
-  api.DocExtractionDiagnosticResponse:
+  api.ExtractionDiagnosticResponse:
     properties:
       amount_regex:
         example: INR\s+([0-9,.]+)
@@ -173,13 +173,13 @@ definitions:
       updated_at:
         type: string
     type: object
-  api.DocExtractionDiagnosticStatusRequest:
+  api.ExtractionDiagnosticStatusRequest:
     properties:
       status:
         example: resolved
         type: string
     type: object
-  api.DocFacetsResponse:
+  api.FacetsResponse:
     properties:
       buckets:
         items:
@@ -206,19 +206,19 @@ definitions:
           type: string
         type: array
     type: object
-  api.DocHealthResponse:
+  api.HealthResponse:
     properties:
       status:
         example: ok
         type: string
     type: object
-  api.DocLabelMappingsResponse:
+  api.LabelMappingsResponse:
     additionalProperties:
       items:
         type: string
       type: array
     type: object
-  api.DocLabelMutationResponse:
+  api.LabelMutationResponse:
     properties:
       color:
         example: '#f59e0b'
@@ -227,7 +227,7 @@ definitions:
         example: food
         type: string
     type: object
-  api.DocLabelResponse:
+  api.LabelResponse:
     properties:
       color:
         example: '#f59e0b'
@@ -238,25 +238,25 @@ definitions:
         example: food
         type: string
     type: object
-  api.DocLookbackDaysRequest:
+  api.LookbackDaysRequest:
     properties:
       lookback_days:
         example: "365"
         type: string
     type: object
-  api.DocLookbackDaysResponse:
+  api.LookbackDaysResponse:
     properties:
       lookback_days:
         example: "365"
         type: string
     type: object
-  api.DocMuteReasonResponse:
+  api.MuteReasonResponse:
     properties:
       reason:
         example: Internal transfer
         type: string
     type: object
-  api.DocMuteTransactionRequest:
+  api.MuteTransactionRequest:
     properties:
       muted:
         type: boolean
@@ -264,7 +264,7 @@ definitions:
         example: Internal transfer
         type: string
     type: object
-  api.DocMuteTransactionResponse:
+  api.MuteTransactionResponse:
     properties:
       muted:
         type: boolean
@@ -272,32 +272,32 @@ definitions:
         example: Internal transfer
         type: string
     type: object
-  api.DocNameResponse:
+  api.NameResponse:
     properties:
       name:
         example: Food
         type: string
     type: object
-  api.DocReaderCheckpointResponse:
+  api.ReaderCheckpointResponse:
     properties:
       last_scan_at:
         example: "2026-04-14T09:00:00Z"
         type: string
         x-nullable: true
     type: object
-  api.DocScanIntervalRequest:
+  api.ScanIntervalRequest:
     properties:
       scan_interval:
         example: "120"
         type: string
     type: object
-  api.DocScanIntervalResponse:
+  api.ScanIntervalResponse:
     properties:
       scan_interval:
         example: "120"
         type: string
     type: object
-  api.DocSetupStatusResponse:
+  api.SetupStatusResponse:
     properties:
       missing:
         example:
@@ -311,7 +311,7 @@ definitions:
         example: true
         type: boolean
     type: object
-  api.DocStatsResponse:
+  api.StatsResponse:
     properties:
       base_currency:
         example: INR
@@ -329,20 +329,20 @@ definitions:
       total_count:
         type: integer
     type: object
-  api.DocStatusOnlyResponse:
+  api.StatusOnlyResponse:
     properties:
       status:
         example: ok
         type: string
     type: object
-  api.DocStatusResponse:
+  api.StatusResponse:
     properties:
       daemon:
         $ref: '#/definitions/api.DaemonStatus'
       stats:
-        $ref: '#/definitions/api.DocStatsResponse'
+        $ref: '#/definitions/api.StatsResponse'
     type: object
-  api.DocSyncStatusResponse:
+  api.SyncStatusResponse:
     properties:
       entries_updated:
         type: integer
@@ -353,38 +353,38 @@ definitions:
         type: string
         x-nullable: true
     type: object
-  api.DocTimeFormatRequest:
+  api.TimeFormatRequest:
     properties:
       time_format:
         example: HH:mm
         type: string
     type: object
-  api.DocTimeFormatResponse:
+  api.TimeFormatResponse:
     properties:
       time_format:
         example: HH:mm
         type: string
     type: object
-  api.DocTimezoneRequest:
+  api.TimezoneRequest:
     properties:
       timezone:
         example: Asia/Kolkata
         type: string
     type: object
-  api.DocTimezoneResponse:
+  api.TimezoneResponse:
     properties:
       timezone:
         example: Asia/Kolkata
         type: string
     type: object
-  api.DocTransactionLabelsRequest:
+  api.TransactionLabelsRequest:
     properties:
       labels:
         items:
           type: string
         type: array
     type: object
-  api.DocTransactionResponse:
+  api.TransactionResponse:
     properties:
       amount:
         example: 249.5
@@ -437,7 +437,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  api.DocTransactionUpdateRequest:
+  api.TransactionUpdateRequest:
     properties:
       bucket:
         example: Needs
@@ -449,7 +449,7 @@ definitions:
         example: Dinner order
         type: string
     type: object
-  api.DocTransactionsListResponse:
+  api.TransactionsListResponse:
     properties:
       base_currency:
         example: INR
@@ -464,10 +464,10 @@ definitions:
         type: number
       transactions:
         items:
-          $ref: '#/definitions/api.DocTransactionResponse'
+          $ref: '#/definitions/api.TransactionResponse'
         type: array
     type: object
-  api.DocTransactionsSearchResponse:
+  api.TransactionsSearchResponse:
     properties:
       base_currency:
         example: INR
@@ -485,22 +485,22 @@ definitions:
         type: number
       transactions:
         items:
-          $ref: '#/definitions/api.DocTransactionResponse'
+          $ref: '#/definitions/api.TransactionResponse'
         type: array
     type: object
-  api.DocUpdateLabelRequest:
+  api.UpdateLabelRequest:
     properties:
       color:
         example: '#f59e0b'
         type: string
     type: object
-  api.DocUpdateMuteReasonRequest:
+  api.UpdateMuteReasonRequest:
     properties:
       reason:
         example: Internal transfer
         type: string
     type: object
-  api.DocVersionResponse:
+  api.VersionResponse:
     properties:
       version:
         example: dev
@@ -520,11 +520,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocActiveReaderResponse'
+            $ref: '#/definitions/api.ActiveReaderResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get the active reader
       tags:
       - Config
@@ -537,7 +537,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/api.DocBankColorResponse'
+              $ref: '#/definitions/api.BankColorResponse'
             type: array
       summary: List bank color mappings
       tags:
@@ -550,11 +550,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocBaseCurrencyResponse'
+            $ref: '#/definitions/api.BaseCurrencyResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get the base currency
       tags:
       - Config
@@ -567,30 +567,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocBaseCurrencyRequest'
+          $ref: '#/definitions/api.BaseCurrencyRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocBaseCurrencyResponse'
+            $ref: '#/definitions/api.BaseCurrencyResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Set the base currency
       tags:
       - Config
@@ -603,16 +603,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/api.DocBucketResponse'
+              $ref: '#/definitions/api.BucketResponse'
             type: array
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: List buckets
       tags:
       - Taxonomy
@@ -625,26 +625,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocCreateBucketRequest'
+          $ref: '#/definitions/api.CreateBucketRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/api.DocNameResponse'
+            $ref: '#/definitions/api.NameResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Create a bucket
       tags:
       - Taxonomy
@@ -664,15 +664,15 @@ paths:
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Delete a bucket
       tags:
       - Taxonomy
@@ -685,16 +685,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/api.DocCategoryResponse'
+              $ref: '#/definitions/api.CategoryResponse'
             type: array
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: List categories
       tags:
       - Taxonomy
@@ -707,26 +707,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocCreateCategoryRequest'
+          $ref: '#/definitions/api.CreateCategoryRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/api.DocNameResponse'
+            $ref: '#/definitions/api.NameResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Create a category
       tags:
       - Taxonomy
@@ -746,15 +746,15 @@ paths:
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Delete a category
       tags:
       - Taxonomy
@@ -767,16 +767,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/api.DocLabelResponse'
+              $ref: '#/definitions/api.LabelResponse'
             type: array
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: List labels
       tags:
       - Taxonomy
@@ -789,26 +789,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocCreateLabelRequest'
+          $ref: '#/definitions/api.CreateLabelRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/api.DocLabelMutationResponse'
+            $ref: '#/definitions/api.LabelMutationResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Create a label
       tags:
       - Taxonomy
@@ -828,11 +828,11 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Delete a label
       tags:
       - Taxonomy
@@ -850,30 +850,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocUpdateLabelRequest'
+          $ref: '#/definitions/api.UpdateLabelRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocLabelMutationResponse'
+            $ref: '#/definitions/api.LabelMutationResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Update a label
       tags:
       - Taxonomy
@@ -892,26 +892,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocApplyLabelRequest'
+          $ref: '#/definitions/api.ApplyLabelRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocAppliedCountResponse'
+            $ref: '#/definitions/api.AppliedCountResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Apply a label by merchant pattern
       tags:
       - Taxonomy
@@ -923,15 +923,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocLabelMappingsResponse'
+            $ref: '#/definitions/api.LabelMappingsResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get label mappings
       tags:
       - Taxonomy
@@ -943,11 +943,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocLookbackDaysResponse'
+            $ref: '#/definitions/api.LookbackDaysResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get lookback days
       tags:
       - Config
@@ -960,30 +960,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocLookbackDaysRequest'
+          $ref: '#/definitions/api.LookbackDaysRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocLookbackDaysResponse'
+            $ref: '#/definitions/api.LookbackDaysResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Set lookback days
       tags:
       - Config
@@ -1003,11 +1003,11 @@ paths:
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Clear a reader checkpoint
       tags:
       - Config
@@ -1024,11 +1024,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocReaderCheckpointResponse'
+            $ref: '#/definitions/api.ReaderCheckpointResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get a reader checkpoint
       tags:
       - Config
@@ -1040,11 +1040,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocScanIntervalResponse'
+            $ref: '#/definitions/api.ScanIntervalResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get the scan interval
       tags:
       - Config
@@ -1057,30 +1057,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocScanIntervalRequest'
+          $ref: '#/definitions/api.ScanIntervalRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocScanIntervalResponse'
+            $ref: '#/definitions/api.ScanIntervalResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Set the scan interval
       tags:
       - Config
@@ -1092,11 +1092,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocSetupStatusResponse'
+            $ref: '#/definitions/api.SetupStatusResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get first-run setup status
       tags:
       - Config
@@ -1110,11 +1110,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocStatusOnlyResponse'
+            $ref: '#/definitions/api.StatusOnlyResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Trigger community content sync
       tags:
       - Config
@@ -1126,15 +1126,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocSyncStatusResponse'
+            $ref: '#/definitions/api.SyncStatusResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get community sync status
       tags:
       - Config
@@ -1146,11 +1146,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocTimeFormatResponse'
+            $ref: '#/definitions/api.TimeFormatResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get the time format
       tags:
       - Config
@@ -1163,30 +1163,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocTimeFormatRequest'
+          $ref: '#/definitions/api.TimeFormatRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocTimeFormatResponse'
+            $ref: '#/definitions/api.TimeFormatResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Set the time format
       tags:
       - Config
@@ -1198,11 +1198,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocTimezoneResponse'
+            $ref: '#/definitions/api.TimezoneResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get the application timezone
       tags:
       - Config
@@ -1215,30 +1215,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocTimezoneRequest'
+          $ref: '#/definitions/api.TimezoneRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocTimezoneResponse'
+            $ref: '#/definitions/api.TimezoneResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Set the application timezone
       tags:
       - Config
@@ -1252,22 +1252,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocDaemonReaderRequest'
+          $ref: '#/definitions/api.DaemonReaderRequest'
       produces:
       - application/json
       responses:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/api.DocStatusOnlyResponse'
+            $ref: '#/definitions/api.StatusOnlyResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "501":
           description: Not Implemented
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Trigger a full rescan
       tags:
       - Bootstrap
@@ -1281,30 +1281,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocDaemonReaderRequest'
+          $ref: '#/definitions/api.DaemonReaderRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Daemon already running
           schema:
-            $ref: '#/definitions/api.DocStatusOnlyResponse'
+            $ref: '#/definitions/api.StatusOnlyResponse'
         "202":
           description: Daemon starting
           schema:
-            $ref: '#/definitions/api.DocStatusOnlyResponse'
+            $ref: '#/definitions/api.StatusOnlyResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "501":
           description: Not Implemented
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Start the daemon
       tags:
       - Bootstrap
@@ -1326,20 +1326,20 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/api.DocExtractionDiagnosticResponse'
+              $ref: '#/definitions/api.ExtractionDiagnosticResponse'
             type: array
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: List extraction diagnostics
       tags:
       - Extraction Diagnostics
@@ -1357,23 +1357,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocExtractionDiagnosticResponse'
+            $ref: '#/definitions/api.ExtractionDiagnosticResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get an extraction diagnostic
       tags:
       - Extraction Diagnostics
@@ -1392,38 +1392,38 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocExtractionDiagnosticStatusRequest'
+          $ref: '#/definitions/api.ExtractionDiagnosticStatusRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocExtractionDiagnosticResponse'
+            $ref: '#/definitions/api.ExtractionDiagnosticResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Update extraction diagnostic status
       tags:
       - Extraction Diagnostics
@@ -1435,7 +1435,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocHealthResponse'
+            $ref: '#/definitions/api.HealthResponse'
       summary: Health check
       tags:
       - Bootstrap
@@ -1447,7 +1447,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocStatusResponse'
+            $ref: '#/definitions/api.StatusResponse'
       summary: Get daemon and stats status
       tags:
       - Bootstrap
@@ -1579,19 +1579,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocTransactionsListResponse'
+            $ref: '#/definitions/api.TransactionsListResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: List transactions
       tags:
       - Transactions
@@ -1609,23 +1609,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocTransactionResponse'
+            $ref: '#/definitions/api.TransactionResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get a transaction
       tags:
       - Transactions
@@ -1643,30 +1643,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocTransactionUpdateRequest'
+          $ref: '#/definitions/api.TransactionUpdateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocTransactionResponse'
+            $ref: '#/definitions/api.TransactionResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Update a transaction
       tags:
       - Transactions
@@ -1685,26 +1685,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocTransactionLabelsRequest'
+          $ref: '#/definitions/api.TransactionLabelsRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocStatusOnlyResponse'
+            $ref: '#/definitions/api.StatusOnlyResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Add labels to a transaction
       tags:
       - Transactions
@@ -1727,19 +1727,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocStatusOnlyResponse'
+            $ref: '#/definitions/api.StatusOnlyResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Remove a label from a transaction
       tags:
       - Transactions
@@ -1758,30 +1758,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocMuteTransactionRequest'
+          $ref: '#/definitions/api.MuteTransactionRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocMuteTransactionResponse'
+            $ref: '#/definitions/api.MuteTransactionResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Mute or unmute a transaction
       tags:
       - Transactions
@@ -1800,30 +1800,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/api.DocUpdateMuteReasonRequest'
+          $ref: '#/definitions/api.UpdateMuteReasonRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocMuteReasonResponse'
+            $ref: '#/definitions/api.MuteReasonResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Update a transaction mute reason
       tags:
       - Transactions
@@ -1835,15 +1835,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocFacetsResponse'
+            $ref: '#/definitions/api.FacetsResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Get transaction facets
       tags:
       - Transactions
@@ -1877,19 +1877,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocTransactionsSearchResponse'
+            $ref: '#/definitions/api.TransactionsSearchResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/api.DocErrorResponse'
+            $ref: '#/definitions/api.ErrorResponse'
       summary: Search transactions
       tags:
       - Transactions
@@ -1901,7 +1901,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.DocVersionResponse'
+            $ref: '#/definitions/api.VersionResponse'
       summary: Get backend version
       tags:
       - Bootstrap

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -127,33 +127,33 @@ func NewHandlers(cfg HandlersConfig) *Handlers {
 
 // --- health & status ---
 
-// HandleHealth handles GET /api/health.
+// Health handles GET /api/health.
 // @Summary Health check
 // @Tags Bootstrap
 // @Produce json
-// @Success 200 {object} DocHealthResponse
+// @Success 200 {object} HealthResponse
 // @Router /health [get]
-func (h *Handlers) HandleHealth(w http.ResponseWriter, _ *http.Request) {
+func (h *Handlers) Health(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-// HandleVersion handles GET /api/version.
+// Version handles GET /api/version.
 // @Summary Get backend version
 // @Tags Bootstrap
 // @Produce json
-// @Success 200 {object} DocVersionResponse
+// @Success 200 {object} VersionResponse
 // @Router /version [get]
-func (h *Handlers) HandleVersion(w http.ResponseWriter, _ *http.Request) {
+func (h *Handlers) Version(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"version": h.version})
 }
 
-// HandleStatus handles GET /api/status.
+// Status handles GET /api/status.
 // @Summary Get daemon and stats status
 // @Tags Bootstrap
 // @Produce json
-// @Success 200 {object} DocStatusResponse
+// @Success 200 {object} StatusResponse
 // @Router /status [get]
-func (h *Handlers) HandleStatus(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) Status(w http.ResponseWriter, r *http.Request) {
 	ds := h.daemon.Status()
 
 	type statusResponse struct {
@@ -163,7 +163,7 @@ func (h *Handlers) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	resp := statusResponse{Daemon: ds}
 
 	if h.store != nil {
-		currency := h.getBaseCurrency(r.Context())
+		currency := h.currentBaseCurrency(r.Context())
 		if stats, err := h.store.GetStats(r.Context(), currency); err == nil {
 			resp.Stats = stats
 		}

--- a/backend/internal/api/handlers_config.go
+++ b/backend/internal/api/handlers_config.go
@@ -9,14 +9,14 @@ import (
 	"time"
 )
 
-// HandleListBanks returns the embedded bank color mappings.
+// ListBanks returns the embedded bank color mappings.
 // GET /api/config/banks
 // @Summary List bank color mappings
 // @Tags Taxonomy
 // @Produce json
-// @Success 200 {array} DocBankColorResponse
+// @Success 200 {array} BankColorResponse
 // @Router /config/banks [get]
-func (h *Handlers) HandleListBanks(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ListBanks(w http.ResponseWriter, r *http.Request) {
 	data := h.banksData
 	if len(data) == 0 {
 		data = []byte("[]")
@@ -28,35 +28,35 @@ func (h *Handlers) HandleListBanks(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// HandleGetBaseCurrency handles GET /api/config/base-currency.
+// GetBaseCurrency handles GET /api/config/base-currency.
 // @Summary Get the base currency
 // @Tags Config
 // @Produce json
-// @Success 200 {object} DocBaseCurrencyResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} BaseCurrencyResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/base-currency [get]
-func (h *Handlers) HandleGetBaseCurrency(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetBaseCurrency(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"base_currency": h.getBaseCurrency(r.Context())})
+	writeJSON(w, http.StatusOK, map[string]string{"base_currency": h.currentBaseCurrency(r.Context())})
 }
 
-// HandleSetBaseCurrency handles PUT /api/config/base-currency.
+// SetBaseCurrency handles PUT /api/config/base-currency.
 // Body: {"base_currency": "USD"}
 // @Summary Set the base currency
 // @Tags Config
 // @Accept json
 // @Produce json
-// @Param request body DocBaseCurrencyRequest true "Base currency payload"
-// @Success 200 {object} DocBaseCurrencyResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body BaseCurrencyRequest true "Base currency payload"
+// @Success 200 {object} BaseCurrencyResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/base-currency [put]
-func (h *Handlers) HandleSetBaseCurrency(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) SetBaseCurrency(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -87,14 +87,14 @@ func (h *Handlers) HandleSetBaseCurrency(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]string{"base_currency": currency})
 }
 
-// HandleGetScanInterval handles GET /api/config/scan-interval.
+// GetScanInterval handles GET /api/config/scan-interval.
 // @Summary Get the scan interval
 // @Tags Config
 // @Produce json
-// @Success 200 {object} DocScanIntervalResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} ScanIntervalResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/scan-interval [get]
-func (h *Handlers) HandleGetScanInterval(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetScanInterval(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -106,20 +106,20 @@ func (h *Handlers) HandleGetScanInterval(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]string{"scan_interval": val})
 }
 
-// HandleSetScanInterval handles PUT /api/config/scan-interval.
+// SetScanInterval handles PUT /api/config/scan-interval.
 // Body: {"scan_interval": "120"}
 // @Summary Set the scan interval
 // @Tags Config
 // @Accept json
 // @Produce json
-// @Param request body DocScanIntervalRequest true "Scan interval payload"
-// @Success 200 {object} DocScanIntervalResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body ScanIntervalRequest true "Scan interval payload"
+// @Success 200 {object} ScanIntervalResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/scan-interval [put]
-func (h *Handlers) HandleSetScanInterval(w http.ResponseWriter, r *http.Request) { //nolint:dupl // same shape as SetLookbackDays; different key and bounds
+func (h *Handlers) SetScanInterval(w http.ResponseWriter, r *http.Request) { //nolint:dupl // same shape as SetLookbackDays; different key and bounds
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -144,14 +144,14 @@ func (h *Handlers) HandleSetScanInterval(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]string{"scan_interval": body.ScanInterval})
 }
 
-// HandleGetLookbackDays handles GET /api/config/lookback-days.
+// GetLookbackDays handles GET /api/config/lookback-days.
 // @Summary Get lookback days
 // @Tags Config
 // @Produce json
-// @Success 200 {object} DocLookbackDaysResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} LookbackDaysResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/lookback-days [get]
-func (h *Handlers) HandleGetLookbackDays(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetLookbackDays(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -163,20 +163,20 @@ func (h *Handlers) HandleGetLookbackDays(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]string{"lookback_days": val})
 }
 
-// HandleSetLookbackDays handles PUT /api/config/lookback-days.
+// SetLookbackDays handles PUT /api/config/lookback-days.
 // Body: {"lookback_days": "365"}
 // @Summary Set lookback days
 // @Tags Config
 // @Accept json
 // @Produce json
-// @Param request body DocLookbackDaysRequest true "Lookback days payload"
-// @Success 200 {object} DocLookbackDaysResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body LookbackDaysRequest true "Lookback days payload"
+// @Success 200 {object} LookbackDaysResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/lookback-days [put]
-func (h *Handlers) HandleSetLookbackDays(w http.ResponseWriter, r *http.Request) { //nolint:dupl // same shape as SetScanInterval; different key and bounds
+func (h *Handlers) SetLookbackDays(w http.ResponseWriter, r *http.Request) { //nolint:dupl // same shape as SetScanInterval; different key and bounds
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -209,14 +209,14 @@ var validTimeFormats = map[string]bool{
 	"h:mm:ss a": true,
 }
 
-// HandleGetTimezone handles GET /api/config/timezone.
+// GetTimezone handles GET /api/config/timezone.
 // @Summary Get the application timezone
 // @Tags Config
 // @Produce json
-// @Success 200 {object} DocTimezoneResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} TimezoneResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/timezone [get]
-func (h *Handlers) HandleGetTimezone(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetTimezone(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -228,20 +228,20 @@ func (h *Handlers) HandleGetTimezone(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"timezone": tz})
 }
 
-// HandleSetTimezone handles PUT /api/config/timezone.
+// SetTimezone handles PUT /api/config/timezone.
 // Body: {"timezone": "Asia/Kolkata"}
 // @Summary Set the application timezone
 // @Tags Config
 // @Accept json
 // @Produce json
-// @Param request body DocTimezoneRequest true "Timezone payload"
-// @Success 200 {object} DocTimezoneResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body TimezoneRequest true "Timezone payload"
+// @Success 200 {object} TimezoneResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/timezone [put]
-func (h *Handlers) HandleSetTimezone(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) SetTimezone(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -266,14 +266,14 @@ func (h *Handlers) HandleSetTimezone(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"timezone": tz})
 }
 
-// HandleGetTimeFormat handles GET /api/config/time-format.
+// GetTimeFormat handles GET /api/config/time-format.
 // @Summary Get the time format
 // @Tags Config
 // @Produce json
-// @Success 200 {object} DocTimeFormatResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} TimeFormatResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/time-format [get]
-func (h *Handlers) HandleGetTimeFormat(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetTimeFormat(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -285,20 +285,20 @@ func (h *Handlers) HandleGetTimeFormat(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"time_format": tf})
 }
 
-// HandleSetTimeFormat handles PUT /api/config/time-format.
+// SetTimeFormat handles PUT /api/config/time-format.
 // Body: {"time_format": "HH:mm"}
 // @Summary Set the time format
 // @Tags Config
 // @Accept json
 // @Produce json
-// @Param request body DocTimeFormatRequest true "Time format payload"
-// @Success 200 {object} DocTimeFormatResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body TimeFormatRequest true "Time format payload"
+// @Success 200 {object} TimeFormatResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/time-format [put]
-func (h *Handlers) HandleSetTimeFormat(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) SetTimeFormat(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -342,14 +342,14 @@ func (h *Handlers) missingSetupPreferences(ctx context.Context) []string {
 	return missing
 }
 
-// HandleGetSetupStatus handles GET /api/config/setup-status.
+// GetSetupStatus handles GET /api/config/setup-status.
 // @Summary Get first-run setup status
 // @Tags Config
 // @Produce json
-// @Success 200 {object} DocSetupStatusResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} SetupStatusResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/setup-status [get]
-func (h *Handlers) HandleGetSetupStatus(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetSetupStatus(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -361,16 +361,16 @@ func (h *Handlers) HandleGetSetupStatus(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// HandleGetReaderCheckpoint handles GET /api/config/readers/{name}/checkpoint.
+// GetReaderCheckpoint handles GET /api/config/readers/{name}/checkpoint.
 // Returns the last scan timestamp for the reader (or null if no checkpoint exists).
 // @Summary Get a reader checkpoint
 // @Tags Config
 // @Produce json
 // @Param name path string true "Reader name"
-// @Success 200 {object} DocReaderCheckpointResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} ReaderCheckpointResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/readers/{name}/checkpoint [get]
-func (h *Handlers) HandleGetReaderCheckpoint(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetReaderCheckpoint(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -384,7 +384,7 @@ func (h *Handlers) HandleGetReaderCheckpoint(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusOK, map[string]any{"last_scan_at": val})
 }
 
-// HandleClearReaderCheckpoint handles DELETE /api/config/readers/{name}/checkpoint.
+// ClearReaderCheckpoint handles DELETE /api/config/readers/{name}/checkpoint.
 // Clears the checkpoint so the next scan processes the full lookback window.
 // If the daemon is currently running, it is restarted so it picks up the
 // now-absent checkpoint immediately rather than waiting for the next interval.
@@ -393,10 +393,10 @@ func (h *Handlers) HandleGetReaderCheckpoint(w http.ResponseWriter, r *http.Requ
 // @Produce json
 // @Param name path string true "Reader name"
 // @Success 204 "No Content"
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/readers/{name}/checkpoint [delete]
-func (h *Handlers) HandleClearReaderCheckpoint(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ClearReaderCheckpoint(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return

--- a/backend/internal/api/handlers_daemon.go
+++ b/backend/internal/api/handlers_daemon.go
@@ -8,21 +8,21 @@ import (
 
 // --- daemon control ---
 
-// HandleStartDaemon handles POST /api/daemon/start.
+// StartDaemon handles POST /api/daemon/start.
 // Body: {"reader": "gmail"}
 // Triggers the background daemon with the given reader if it is not already running.
 // @Summary Start the daemon
 // @Tags Bootstrap
 // @Accept json
 // @Produce json
-// @Param request body DocDaemonReaderRequest true "Daemon start request"
-// @Success 200 {object} DocStatusOnlyResponse "Daemon already running"
-// @Success 202 {object} DocStatusOnlyResponse "Daemon starting"
-// @Failure 400 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 501 {object} DocErrorResponse
+// @Param request body DaemonReaderRequest true "Daemon start request"
+// @Success 200 {object} StatusOnlyResponse "Daemon already running"
+// @Success 202 {object} StatusOnlyResponse "Daemon starting"
+// @Failure 400 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 501 {object} ErrorResponse
 // @Router /daemon/start [post]
-func (h *Handlers) HandleStartDaemon(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) StartDaemon(w http.ResponseWriter, r *http.Request) {
 	if h.startFn == nil {
 		writeError(w, http.StatusNotImplemented, "daemon start not configured")
 		return
@@ -49,7 +49,7 @@ func (h *Handlers) HandleStartDaemon(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "starting"})
 }
 
-// HandleRescan handles POST /api/daemon/rescan.
+// Rescan handles POST /api/daemon/rescan.
 // Body: {"reader": "<name>"}
 // Stops any running daemon and restarts with forceRescan=true, bypassing the
 // checkpoint and state deduplication so the full lookback window is scanned.
@@ -57,12 +57,12 @@ func (h *Handlers) HandleStartDaemon(w http.ResponseWriter, r *http.Request) {
 // @Tags Bootstrap
 // @Accept json
 // @Produce json
-// @Param request body DocDaemonReaderRequest true "Daemon rescan request"
-// @Success 202 {object} DocStatusOnlyResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 501 {object} DocErrorResponse
+// @Param request body DaemonReaderRequest true "Daemon rescan request"
+// @Success 202 {object} StatusOnlyResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 501 {object} ErrorResponse
 // @Router /daemon/rescan [post]
-func (h *Handlers) HandleRescan(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) Rescan(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Reader string `json:"reader"`
 	}
@@ -83,15 +83,15 @@ func (h *Handlers) HandleRescan(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "rescanning"})
 }
 
-// HandleGetActiveReader handles GET /api/config/active-reader.
+// GetActiveReader handles GET /api/config/active-reader.
 // Returns the reader name persisted from the last daemon start, or "" if none.
 // @Summary Get the active reader
 // @Tags Config
 // @Produce json
-// @Success 200 {object} DocActiveReaderResponse
-// @Failure 500 {object} DocErrorResponse
+// @Success 200 {object} ActiveReaderResponse
+// @Failure 500 {object} ErrorResponse
 // @Router /config/active-reader [get]
-func (h *Handlers) HandleGetActiveReader(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetActiveReader(w http.ResponseWriter, r *http.Request) {
 	reader, err := h.readActiveReader(r.Context())
 	if err != nil {
 		h.logger.Error("failed to read active reader", "error", err)

--- a/backend/internal/api/handlers_diagnostics.go
+++ b/backend/internal/api/handlers_diagnostics.go
@@ -11,18 +11,18 @@ import (
 	"github.com/ArionMiles/expensor/backend/internal/store"
 )
 
-// HandleListExtractionDiagnostics handles GET /api/extraction-diagnostics.
+// ListExtractionDiagnostics handles GET /api/extraction-diagnostics.
 // @Summary List extraction diagnostics
 // @Tags Extraction Diagnostics
 // @Produce json
 // @Param status query string false "Diagnostic status filter"
 // @Param limit query int false "Maximum rows to return"
-// @Success 200 {array} DocExtractionDiagnosticResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {array} ExtractionDiagnosticResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /extraction-diagnostics [get]
-func (h *Handlers) HandleListExtractionDiagnostics(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ListExtractionDiagnostics(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -59,18 +59,18 @@ func (h *Handlers) HandleListExtractionDiagnostics(w http.ResponseWriter, r *htt
 	writeJSON(w, http.StatusOK, rows)
 }
 
-// HandleGetExtractionDiagnostic handles GET /api/extraction-diagnostics/{id}.
+// GetExtractionDiagnostic handles GET /api/extraction-diagnostics/{id}.
 // @Summary Get an extraction diagnostic
 // @Tags Extraction Diagnostics
 // @Produce json
 // @Param id path string true "Diagnostic ID"
-// @Success 200 {object} DocExtractionDiagnosticResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 404 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} ExtractionDiagnosticResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /extraction-diagnostics/{id} [get]
-func (h *Handlers) HandleGetExtractionDiagnostic(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetExtractionDiagnostic(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -95,22 +95,22 @@ func (h *Handlers) HandleGetExtractionDiagnostic(w http.ResponseWriter, r *http.
 	writeJSON(w, http.StatusOK, row)
 }
 
-// HandleUpdateExtractionDiagnosticStatus handles PUT /api/extraction-diagnostics/{id}/status.
+// UpdateExtractionDiagnosticStatus handles PUT /api/extraction-diagnostics/{id}/status.
 // @Summary Update extraction diagnostic status
 // @Tags Extraction Diagnostics
 // @Accept json
 // @Produce json
 // @Param id path string true "Diagnostic ID"
-// @Param request body DocExtractionDiagnosticStatusRequest true "Diagnostic status payload"
-// @Success 200 {object} DocExtractionDiagnosticResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 404 {object} DocErrorResponse
-// @Failure 409 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body ExtractionDiagnosticStatusRequest true "Diagnostic status payload"
+// @Success 200 {object} ExtractionDiagnosticResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 409 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /extraction-diagnostics/{id}/status [put]
-func (h *Handlers) HandleUpdateExtractionDiagnosticStatus(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) UpdateExtractionDiagnosticStatus(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -122,7 +122,7 @@ func (h *Handlers) HandleUpdateExtractionDiagnosticStatus(w http.ResponseWriter,
 		return
 	}
 
-	var body DocExtractionDiagnosticStatusRequest
+	var body ExtractionDiagnosticStatusRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusUnprocessableEntity, "invalid JSON body")
 		return

--- a/backend/internal/api/handlers_readers.go
+++ b/backend/internal/api/handlers_readers.go
@@ -37,8 +37,8 @@ type WriterInfo struct {
 	Description string `json:"description"`
 }
 
-// HandleListReaders handles GET /api/plugins/readers.
-func (h *Handlers) HandleListReaders(w http.ResponseWriter, _ *http.Request) {
+// ListReaders handles GET /api/plugins/readers.
+func (h *Handlers) ListReaders(w http.ResponseWriter, _ *http.Request) {
 	rps := h.registry.ListReaders()
 	infos := make([]ReaderInfo, 0, len(rps))
 	for _, p := range rps {
@@ -58,8 +58,8 @@ func (h *Handlers) HandleListReaders(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, infos)
 }
 
-// HandleListWriters handles GET /api/plugins/writers.
-func (h *Handlers) HandleListWriters(w http.ResponseWriter, _ *http.Request) {
+// ListWriters handles GET /api/plugins/writers.
+func (h *Handlers) ListWriters(w http.ResponseWriter, _ *http.Request) {
 	wps := h.registry.ListWriters()
 	infos := make([]WriterInfo, 0, len(wps))
 	for _, p := range wps {
@@ -74,9 +74,9 @@ func (h *Handlers) HandleListWriters(w http.ResponseWriter, _ *http.Request) {
 
 // --- reader credentials upload ---
 
-// HandleUploadCredentials handles POST /api/readers/{name}/credentials.
+// UploadCredentials handles POST /api/readers/{name}/credentials.
 // Accepts a JSON file upload (e.g. Google client_secret.json) and saves it to the runtime store.
-func (h *Handlers) HandleUploadCredentials(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) UploadCredentials(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	plugin, err := h.registry.GetReader(name)
 	if err != nil {
@@ -126,8 +126,8 @@ func (h *Handlers) HandleUploadCredentials(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, map[string]string{"path": fmt.Sprintf("db://reader_runtime/%s/client_secret", name)})
 }
 
-// HandleCredentialsStatus handles GET /api/readers/{name}/credentials/status.
-func (h *Handlers) HandleCredentialsStatus(w http.ResponseWriter, r *http.Request) {
+// CredentialsStatus handles GET /api/readers/{name}/credentials/status.
+func (h *Handlers) CredentialsStatus(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if _, err := h.registry.GetReader(name); err != nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
@@ -149,9 +149,9 @@ func (h *Handlers) HandleCredentialsStatus(w http.ResponseWriter, r *http.Reques
 
 // --- OAuth flow ---
 
-// HandleAuthStart handles POST /api/readers/{name}/auth/start.
+// AuthStart handles POST /api/readers/{name}/auth/start.
 // Returns a Google OAuth consent URL for the given reader.
-func (h *Handlers) HandleAuthStart(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) AuthStart(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	plugin, err := h.registry.GetReader(name)
 	if err != nil {
@@ -267,9 +267,9 @@ func (h *Handlers) restartReaderDaemonAfterAuth(name string) {
 	}
 }
 
-// HandleAuthCallback handles GET /api/auth/callback.
+// AuthCallback handles GET /api/auth/callback.
 // This is the shared OAuth redirect target for all readers.
-func (h *Handlers) HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) AuthCallback(w http.ResponseWriter, r *http.Request) {
 	state := r.URL.Query().Get("state")
 	code := r.URL.Query().Get("code")
 
@@ -302,11 +302,11 @@ func (h *Handlers) HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, h.frontendURL+"/setup?auth=success&reader="+url.QueryEscape(name), http.StatusFound)
 }
 
-// HandleAuthExchange handles POST /api/readers/{name}/auth/exchange.
+// AuthExchange handles POST /api/readers/{name}/auth/exchange.
 // Accepts the full redirect URL (containing code and state params) pasted by
 // the user when the automatic redirect is unreachable (e.g. homeserver without
 // a public domain). Validates state, exchanges the code, and saves the token.
-func (h *Handlers) HandleAuthExchange(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) AuthExchange(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 
 	var body struct {
@@ -362,8 +362,8 @@ func (h *Handlers) HandleAuthExchange(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "authorized"})
 }
 
-// HandleAuthStatus handles GET /api/readers/{name}/auth/status.
-func (h *Handlers) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
+// AuthStatus handles GET /api/readers/{name}/auth/status.
+func (h *Handlers) AuthStatus(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	plugin, err := h.registry.GetReader(name)
 	if err != nil {
@@ -403,9 +403,9 @@ func (h *Handlers) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// HandleDisconnectReader handles DELETE /api/readers/{name}.
+// DisconnectReader handles DELETE /api/readers/{name}.
 // Removes all stored credentials, token, and config files for the reader.
-func (h *Handlers) HandleDisconnectReader(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) DisconnectReader(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if _, err := h.registry.GetReader(name); err != nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
@@ -426,8 +426,8 @@ func (h *Handlers) HandleDisconnectReader(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, map[string]any{"status": "disconnected", "files_removed": []string{}})
 }
 
-// HandleRevokeToken handles DELETE /api/readers/{name}/auth/token.
-func (h *Handlers) HandleRevokeToken(w http.ResponseWriter, r *http.Request) {
+// RevokeToken handles DELETE /api/readers/{name}/auth/token.
+func (h *Handlers) RevokeToken(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if _, err := h.registry.GetReader(name); err != nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
@@ -458,8 +458,8 @@ func (h *Handlers) HandleRevokeToken(w http.ResponseWriter, r *http.Request) {
 
 // --- reader config (for config-only readers like Thunderbird) ---
 
-// HandleGetReaderConfig handles GET /api/readers/{name}/config.
-func (h *Handlers) HandleGetReaderConfig(w http.ResponseWriter, r *http.Request) {
+// GetReaderConfig handles GET /api/readers/{name}/config.
+func (h *Handlers) GetReaderConfig(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if _, err := h.registry.GetReader(name); err != nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
@@ -486,8 +486,8 @@ func (h *Handlers) HandleGetReaderConfig(w http.ResponseWriter, r *http.Request)
 	_, _ = w.Write(data) //nolint:gosec // data is JSON read from a known config file; Content-Type is already set to application/json
 }
 
-// HandleSaveReaderConfig handles POST /api/readers/{name}/config.
-func (h *Handlers) HandleSaveReaderConfig(w http.ResponseWriter, r *http.Request) {
+// SaveReaderConfig handles POST /api/readers/{name}/config.
+func (h *Handlers) SaveReaderConfig(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if _, err := h.registry.GetReader(name); err != nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("reader %q not found", name))
@@ -522,9 +522,9 @@ func (h *Handlers) HandleSaveReaderConfig(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, map[string]string{"status": "saved"})
 }
 
-// HandleReaderStatus handles GET /api/readers/{name}/status.
+// ReaderStatus handles GET /api/readers/{name}/status.
 // Returns overall readiness: credentials present, auth valid, config present.
-func (h *Handlers) HandleReaderStatus(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ReaderStatus(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	plugin, err := h.registry.GetReader(name)
 	if err != nil {
@@ -575,10 +575,10 @@ func (h *Handlers) HandleReaderStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, st)
 }
 
-// HandleDiscoverProfiles handles GET /api/readers/thunderbird/discover/profiles.
+// DiscoverProfiles handles GET /api/readers/thunderbird/discover/profiles.
 // Returns discovered Thunderbird profile directories from platform paths,
 // the Docker mount /thunderbird-profile, and THUNDERBIRD_DATA_DIR env var.
-func (h *Handlers) HandleDiscoverProfiles(w http.ResponseWriter, _ *http.Request) {
+func (h *Handlers) DiscoverProfiles(w http.ResponseWriter, _ *http.Request) {
 	var paths []string
 	seen := make(map[string]struct{})
 
@@ -608,9 +608,9 @@ func (h *Handlers) HandleDiscoverProfiles(w http.ResponseWriter, _ *http.Request
 	writeJSON(w, http.StatusOK, map[string][]string{"profiles": paths})
 }
 
-// HandleDiscoverMailboxes handles GET /api/readers/thunderbird/discover/mailboxes?profile=<path>.
+// DiscoverMailboxes handles GET /api/readers/thunderbird/discover/mailboxes?profile=<path>.
 // Returns available MBOX mailbox names within the given Thunderbird profile directory.
-func (h *Handlers) HandleDiscoverMailboxes(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) DiscoverMailboxes(w http.ResponseWriter, r *http.Request) {
 	profile := r.URL.Query().Get("profile")
 	if profile == "" {
 		writeError(w, http.StatusBadRequest, "profile query parameter is required")
@@ -632,9 +632,9 @@ func (h *Handlers) HandleDiscoverMailboxes(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, map[string][]string{"mailboxes": mailboxes})
 }
 
-// HandleGetReaderGuide handles GET /api/readers/{name}/guide.
+// GetReaderGuide handles GET /api/readers/{name}/guide.
 // Returns the structured setup guide for a reader when metadata includes one.
-func (h *Handlers) HandleGetReaderGuide(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetReaderGuide(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	plugin, err := h.registry.GetReader(name)
 	if err != nil {

--- a/backend/internal/api/handlers_rules.go
+++ b/backend/internal/api/handlers_rules.go
@@ -239,8 +239,8 @@ func validateRuleRow(row store.RuleRow) error {
 	return validateRuleRegexes(row.AmountRegex, row.MerchantRegex, row.CurrencyRegex)
 }
 
-// HandleListRules handles GET /api/rules.
-func (h *Handlers) HandleListRules(w http.ResponseWriter, r *http.Request) {
+// ListRules handles GET /api/rules.
+func (h *Handlers) ListRules(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -254,8 +254,8 @@ func (h *Handlers) HandleListRules(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, ruleRowsToHTTP(rules))
 }
 
-// HandleCreateRule handles POST /api/rules.
-func (h *Handlers) HandleCreateRule(w http.ResponseWriter, r *http.Request) {
+// CreateRule handles POST /api/rules.
+func (h *Handlers) CreateRule(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -306,9 +306,9 @@ func (h *Handlers) readActiveReader(ctx context.Context) (string, error) {
 	return h.store.GetActiveReader(ctx)
 }
 
-// HandleUpdateRule handles PUT /api/rules/{id}.
+// UpdateRule handles PUT /api/rules/{id}.
 // All rules (predefined and user-created) are fully editable.
-func (h *Handlers) HandleUpdateRule(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) UpdateRule(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -341,9 +341,9 @@ func (h *Handlers) HandleUpdateRule(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, ruleRowToHTTP(*updated))
 }
 
-// HandleDeleteRule handles DELETE /api/rules/{id}.
+// DeleteRule handles DELETE /api/rules/{id}.
 // Returns 403 for system rules.
-func (h *Handlers) HandleDeleteRule(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) DeleteRule(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -374,9 +374,9 @@ func (h *Handlers) HandleDeleteRule(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// HandleExportRules handles GET /api/rules/export.
+// ExportRules handles GET /api/rules/export.
 // Downloads all user rules as a JSON file in rules.json format.
-func (h *Handlers) HandleExportRules(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ExportRules(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -400,9 +400,9 @@ func (h *Handlers) HandleExportRules(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(ruleDocumentJSON{Version: 2, Presets: ruleDocumentPresets(export), Rules: export})
 }
 
-// HandleImportRules handles POST /api/rules/import.
+// ImportRules handles POST /api/rules/import.
 // Validates all rules first; rejects the entire import if any rule fails.
-func (h *Handlers) HandleImportRules(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ImportRules(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return

--- a/backend/internal/api/handlers_stats.go
+++ b/backend/internal/api/handlers_stats.go
@@ -7,8 +7,8 @@ import (
 	"time"
 )
 
-// HandleGetChartData handles GET /api/stats/charts.
-func (h *Handlers) HandleGetChartData(w http.ResponseWriter, r *http.Request) {
+// GetChartData handles GET /api/stats/charts.
+func (h *Handlers) GetChartData(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -22,8 +22,8 @@ func (h *Handlers) HandleGetChartData(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, cd)
 }
 
-// HandleGetDashboardData handles GET /api/stats/dashboard.
-func (h *Handlers) HandleGetDashboardData(w http.ResponseWriter, r *http.Request) {
+// GetDashboardData handles GET /api/stats/dashboard.
+func (h *Handlers) GetDashboardData(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -39,10 +39,10 @@ func (h *Handlers) HandleGetDashboardData(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, data)
 }
 
-// HandleGetHeatmap handles GET /api/stats/heatmap.
+// GetHeatmap handles GET /api/stats/heatmap.
 // Optional query params: from=<RFC3339>, to=<RFC3339> (both or neither).
 // Returns 400 if either param is present but malformed.
-func (h *Handlers) HandleGetHeatmap(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetHeatmap(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -63,10 +63,10 @@ func (h *Handlers) HandleGetHeatmap(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, data)
 }
 
-// HandleGetAnnualHeatmap handles GET /api/stats/heatmap/annual?year=YYYY.
+// GetAnnualHeatmap handles GET /api/stats/heatmap/annual?year=YYYY.
 // Returns per-day transaction totals for the requested calendar year.
 // Defaults to the current year when ?year is absent or invalid.
-func (h *Handlers) HandleGetAnnualHeatmap(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetAnnualHeatmap(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return

--- a/backend/internal/api/handlers_sync.go
+++ b/backend/internal/api/handlers_sync.go
@@ -2,16 +2,16 @@ package api
 
 import "net/http"
 
-// HandleTriggerSync triggers an immediate community content sync.
+// TriggerSync triggers an immediate community content sync.
 // POST /api/config/sync
 // @Summary Trigger community content sync
 // @Tags Config
 // @Accept json
 // @Produce json
-// @Success 200 {object} DocStatusOnlyResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} StatusOnlyResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/sync [post]
-func (h *Handlers) HandleTriggerSync(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) TriggerSync(w http.ResponseWriter, r *http.Request) {
 	if h.syncFn == nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "sync not configured"})
 		return
@@ -20,16 +20,16 @@ func (h *Handlers) HandleTriggerSync(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-// HandleGetSyncStatus returns the last community sync status.
+// GetSyncStatus returns the last community sync status.
 // GET /api/config/sync/status
 // @Summary Get community sync status
 // @Tags Config
 // @Produce json
-// @Success 200 {object} DocSyncStatusResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} SyncStatusResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/sync/status [get]
-func (h *Handlers) HandleGetSyncStatus(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetSyncStatus(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return

--- a/backend/internal/api/handlers_taxonomy.go
+++ b/backend/internal/api/handlers_taxonomy.go
@@ -12,15 +12,15 @@ import (
 	"github.com/ArionMiles/expensor/backend/internal/store"
 )
 
-// HandleListLabels handles GET /api/config/labels.
+// ListLabels handles GET /api/config/labels.
 // @Summary List labels
 // @Tags Taxonomy
 // @Produce json
-// @Success 200 {array} DocLabelResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {array} LabelResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/labels [get]
-func (h *Handlers) HandleListLabels(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ListLabels(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -34,19 +34,19 @@ func (h *Handlers) HandleListLabels(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, labels)
 }
 
-// HandleCreateLabel handles POST /api/config/labels.
+// CreateLabel handles POST /api/config/labels.
 // Body: {"name": "food", "color": "#f59e0b"}
 // @Summary Create a label
 // @Tags Taxonomy
 // @Accept json
 // @Produce json
-// @Param request body DocCreateLabelRequest true "Label payload"
-// @Success 201 {object} DocLabelMutationResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body CreateLabelRequest true "Label payload"
+// @Success 201 {object} LabelMutationResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/labels [post]
-func (h *Handlers) HandleCreateLabel(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) CreateLabel(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -70,21 +70,21 @@ func (h *Handlers) HandleCreateLabel(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, map[string]string{"name": body.Name, "color": body.Color})
 }
 
-// HandleUpdateLabel handles PUT /api/config/labels/{name}.
+// UpdateLabel handles PUT /api/config/labels/{name}.
 // Body: {"color": "#f59e0b"}
 // @Summary Update a label
 // @Tags Taxonomy
 // @Accept json
 // @Produce json
 // @Param name path string true "Label name"
-// @Param request body DocUpdateLabelRequest true "Label color payload"
-// @Success 200 {object} DocLabelMutationResponse
-// @Failure 404 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body UpdateLabelRequest true "Label color payload"
+// @Success 200 {object} LabelMutationResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/labels/{name} [put]
-func (h *Handlers) HandleUpdateLabel(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) UpdateLabel(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -109,17 +109,17 @@ func (h *Handlers) HandleUpdateLabel(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"name": name, "color": body.Color})
 }
 
-// HandleDeleteLabel handles DELETE /api/config/labels/{name}.
+// DeleteLabel handles DELETE /api/config/labels/{name}.
 // Body: {"remove_from_transactions": true}
 // @Summary Delete a label
 // @Tags Taxonomy
 // @Produce json
 // @Param name path string true "Label name"
 // @Success 204 "No Content"
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/labels/{name} [delete]
-func (h *Handlers) HandleDeleteLabel(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) DeleteLabel(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -137,20 +137,20 @@ func (h *Handlers) HandleDeleteLabel(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// HandleApplyLabel handles POST /api/config/labels/{name}/apply.
+// ApplyLabel handles POST /api/config/labels/{name}/apply.
 // Body: {"merchant_pattern": "swiggy"}
 // @Summary Apply a label by merchant pattern
 // @Tags Taxonomy
 // @Accept json
 // @Produce json
 // @Param name path string true "Label name"
-// @Param request body DocApplyLabelRequest true "Merchant pattern payload"
-// @Success 200 {object} DocAppliedCountResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body ApplyLabelRequest true "Merchant pattern payload"
+// @Success 200 {object} AppliedCountResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/labels/{name}/apply [post]
-func (h *Handlers) HandleApplyLabel(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ApplyLabel(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -172,9 +172,9 @@ func (h *Handlers) HandleApplyLabel(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"applied": affected})
 }
 
-// HandleRemoveLabelByMerchant handles DELETE /api/config/labels/{name}/merchant.
+// RemoveLabelByMerchant handles DELETE /api/config/labels/{name}/merchant.
 // Body: {"merchant_pattern": "swiggy"}
-func (h *Handlers) HandleRemoveLabelByMerchant(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) RemoveLabelByMerchant(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -196,12 +196,12 @@ func (h *Handlers) HandleRemoveLabelByMerchant(w http.ResponseWriter, r *http.Re
 	writeJSON(w, http.StatusOK, map[string]any{"removed": removed})
 }
 
-// HandleGetLabelMonthlySpend handles GET /api/stats/labels/monthly.
+// GetLabelMonthlySpend handles GET /api/stats/labels/monthly.
 // Query params:
 //   - dimension=labels|categories|buckets (default: labels)
 //
 // Response: {"labels":["Food","Travel"], "months":["2025-05","2025-06",...], "series":[{"label":"Food","data":[...]}]}
-func (h *Handlers) HandleGetLabelMonthlySpend(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetLabelMonthlySpend(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -227,16 +227,16 @@ func (h *Handlers) HandleGetLabelMonthlySpend(w http.ResponseWriter, r *http.Req
 	writeJSON(w, http.StatusOK, data)
 }
 
-// HandleGetLabelMappings handles GET /api/config/labels/mappings.
+// GetLabelMappings handles GET /api/config/labels/mappings.
 // Returns a map of label → persisted merchant patterns.
 // @Summary Get label mappings
 // @Tags Taxonomy
 // @Produce json
-// @Success 200 {object} DocLabelMappingsResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} LabelMappingsResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/labels/mappings [get]
-func (h *Handlers) HandleGetLabelMappings(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetLabelMappings(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -250,9 +250,9 @@ func (h *Handlers) HandleGetLabelMappings(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, mappings)
 }
 
-// HandleExportLabels handles GET /api/config/labels/export.
+// ExportLabels handles GET /api/config/labels/export.
 // Returns labels with their persisted merchant mappings as a downloadable JSON file.
-func (h *Handlers) HandleExportLabels(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ExportLabels(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -288,9 +288,9 @@ func (h *Handlers) HandleExportLabels(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(export)
 }
 
-// HandleExportCategories handles GET /api/config/categories/export.
+// ExportCategories handles GET /api/config/categories/export.
 // Returns categories with their persisted merchant mappings as a downloadable JSON file.
-func (h *Handlers) HandleExportCategories(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ExportCategories(w http.ResponseWriter, r *http.Request) {
 	handleExportNamedTaxonomy(w, r, taxonomyExportConfig[store.Category]{
 		handlers:    h,
 		singular:    "category",
@@ -302,8 +302,8 @@ func (h *Handlers) HandleExportCategories(w http.ResponseWriter, r *http.Request
 	})
 }
 
-// HandleGetCategoryMappings handles GET /api/config/categories/mappings.
-func (h *Handlers) HandleGetCategoryMappings(w http.ResponseWriter, r *http.Request) {
+// GetCategoryMappings handles GET /api/config/categories/mappings.
+func (h *Handlers) GetCategoryMappings(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -317,15 +317,15 @@ func (h *Handlers) HandleGetCategoryMappings(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusOK, mappings)
 }
 
-// HandleListCategories handles GET /api/config/categories.
+// ListCategories handles GET /api/config/categories.
 // @Summary List categories
 // @Tags Taxonomy
 // @Produce json
-// @Success 200 {array} DocCategoryResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {array} CategoryResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/categories [get]
-func (h *Handlers) HandleListCategories(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ListCategories(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -339,18 +339,18 @@ func (h *Handlers) HandleListCategories(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, cats)
 }
 
-// HandleCreateCategory handles POST /api/config/categories.
+// CreateCategory handles POST /api/config/categories.
 // @Summary Create a category
 // @Tags Taxonomy
 // @Accept json
 // @Produce json
-// @Param request body DocCreateCategoryRequest true "Category payload"
-// @Success 201 {object} DocNameResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body CreateCategoryRequest true "Category payload"
+// @Success 201 {object} NameResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/categories [post]
-func (h *Handlers) HandleCreateCategory(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) CreateCategory(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -371,17 +371,17 @@ func (h *Handlers) HandleCreateCategory(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusCreated, map[string]string{"name": body.Name})
 }
 
-// HandleDeleteCategory handles DELETE /api/config/categories/{name}.
+// DeleteCategory handles DELETE /api/config/categories/{name}.
 // @Summary Delete a category
 // @Tags Taxonomy
 // @Produce json
 // @Param name path string true "Category name"
 // @Success 204 "No Content"
-// @Failure 404 {object} DocErrorResponse
-// @Failure 409 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 409 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/categories/{name} [delete]
-func (h *Handlers) HandleDeleteCategory(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) DeleteCategory(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -403,25 +403,25 @@ func (h *Handlers) HandleDeleteCategory(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// HandleApplyCategoryByMerchant handles POST /api/config/categories/{name}/apply.
-func (h *Handlers) HandleApplyCategoryByMerchant(w http.ResponseWriter, r *http.Request) {
+// ApplyCategoryByMerchant handles POST /api/config/categories/{name}/apply.
+func (h *Handlers) ApplyCategoryByMerchant(w http.ResponseWriter, r *http.Request) {
 	h.handleApplyTaxonomyMerchant(w, r, "category", h.store.ApplyCategoryByMerchant)
 }
 
-// HandleRemoveCategoryByMerchant handles DELETE /api/config/categories/{name}/merchant.
-func (h *Handlers) HandleRemoveCategoryByMerchant(w http.ResponseWriter, r *http.Request) {
+// RemoveCategoryByMerchant handles DELETE /api/config/categories/{name}/merchant.
+func (h *Handlers) RemoveCategoryByMerchant(w http.ResponseWriter, r *http.Request) {
 	h.handleRemoveTaxonomyMerchant(w, r, "category", h.store.RemoveCategoryByMerchant)
 }
 
-// HandleListBuckets handles GET /api/config/buckets.
+// ListBuckets handles GET /api/config/buckets.
 // @Summary List buckets
 // @Tags Taxonomy
 // @Produce json
-// @Success 200 {array} DocBucketResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {array} BucketResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/buckets [get]
-func (h *Handlers) HandleListBuckets(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ListBuckets(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -435,18 +435,18 @@ func (h *Handlers) HandleListBuckets(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, bkts)
 }
 
-// HandleCreateBucket handles POST /api/config/buckets.
+// CreateBucket handles POST /api/config/buckets.
 // @Summary Create a bucket
 // @Tags Taxonomy
 // @Accept json
 // @Produce json
-// @Param request body DocCreateBucketRequest true "Bucket payload"
-// @Success 201 {object} DocNameResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body CreateBucketRequest true "Bucket payload"
+// @Success 201 {object} NameResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/buckets [post]
-func (h *Handlers) HandleCreateBucket(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) CreateBucket(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -467,17 +467,17 @@ func (h *Handlers) HandleCreateBucket(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, map[string]string{"name": body.Name})
 }
 
-// HandleDeleteBucket handles DELETE /api/config/buckets/{name}.
+// DeleteBucket handles DELETE /api/config/buckets/{name}.
 // @Summary Delete a bucket
 // @Tags Taxonomy
 // @Produce json
 // @Param name path string true "Bucket name"
 // @Success 204 "No Content"
-// @Failure 404 {object} DocErrorResponse
-// @Failure 409 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 409 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /config/buckets/{name} [delete]
-func (h *Handlers) HandleDeleteBucket(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -498,9 +498,9 @@ func (h *Handlers) HandleDeleteBucket(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// HandleExportBuckets handles GET /api/config/buckets/export.
+// ExportBuckets handles GET /api/config/buckets/export.
 // Returns buckets with their persisted merchant mappings as a downloadable JSON file.
-func (h *Handlers) HandleExportBuckets(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ExportBuckets(w http.ResponseWriter, r *http.Request) {
 	handleExportNamedTaxonomy(w, r, taxonomyExportConfig[store.Bucket]{
 		handlers:    h,
 		singular:    "bucket",
@@ -512,8 +512,8 @@ func (h *Handlers) HandleExportBuckets(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// HandleGetBucketMappings handles GET /api/config/buckets/mappings.
-func (h *Handlers) HandleGetBucketMappings(w http.ResponseWriter, r *http.Request) {
+// GetBucketMappings handles GET /api/config/buckets/mappings.
+func (h *Handlers) GetBucketMappings(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -527,13 +527,13 @@ func (h *Handlers) HandleGetBucketMappings(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, mappings)
 }
 
-// HandleApplyBucketByMerchant handles POST /api/config/buckets/{name}/apply.
-func (h *Handlers) HandleApplyBucketByMerchant(w http.ResponseWriter, r *http.Request) {
+// ApplyBucketByMerchant handles POST /api/config/buckets/{name}/apply.
+func (h *Handlers) ApplyBucketByMerchant(w http.ResponseWriter, r *http.Request) {
 	h.handleApplyTaxonomyMerchant(w, r, "bucket", h.store.ApplyBucketByMerchant)
 }
 
-// HandleRemoveBucketByMerchant handles DELETE /api/config/buckets/{name}/merchant.
-func (h *Handlers) HandleRemoveBucketByMerchant(w http.ResponseWriter, r *http.Request) {
+// RemoveBucketByMerchant handles DELETE /api/config/buckets/{name}/merchant.
+func (h *Handlers) RemoveBucketByMerchant(w http.ResponseWriter, r *http.Request) {
 	h.handleRemoveTaxonomyMerchant(w, r, "bucket", h.store.RemoveBucketByMerchant)
 }
 
@@ -660,20 +660,20 @@ func (h *Handlers) handleTaxonomyMerchant(
 	writeJSON(w, http.StatusOK, map[string]any{action.responseKey: count})
 }
 
-// HandleAddLabels handles POST /api/transactions/{id}/labels.
+// AddLabels handles POST /api/transactions/{id}/labels.
 // Body: {"labels": ["food", "recurring"]}
 // @Summary Add labels to a transaction
 // @Tags Transactions
 // @Accept json
 // @Produce json
 // @Param id path string true "Transaction ID"
-// @Param request body DocTransactionLabelsRequest true "Labels payload"
-// @Success 200 {object} DocStatusOnlyResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body TransactionLabelsRequest true "Labels payload"
+// @Success 200 {object} StatusOnlyResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id}/labels [post]
-func (h *Handlers) HandleAddLabels(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) AddLabels(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -697,18 +697,18 @@ func (h *Handlers) HandleAddLabels(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "added"})
 }
 
-// HandleRemoveLabel handles DELETE /api/transactions/{id}/labels/{label}.
+// RemoveLabel handles DELETE /api/transactions/{id}/labels/{label}.
 // @Summary Remove a label from a transaction
 // @Tags Transactions
 // @Produce json
 // @Param id path string true "Transaction ID"
 // @Param label path string true "Label name"
-// @Success 200 {object} DocStatusOnlyResponse
-// @Failure 404 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} StatusOnlyResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id}/labels/{label} [delete]
-func (h *Handlers) HandleRemoveLabel(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) RemoveLabel(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -636,9 +636,9 @@ func decodeJSON(t *testing.T, body string, v any) {
 
 // --- health ---
 
-func TestHandleHealth(t *testing.T) {
+func TestHealth(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.HandleHealth, "/api/health")
+	rr := get(h.Health, "/api/health")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -652,10 +652,10 @@ func TestHandleHealth(t *testing.T) {
 
 // --- status ---
 
-func TestHandleStatus_NilStore(t *testing.T) {
+func TestStatus_NilStore(t *testing.T) {
 	dm := &mockDaemon{status: DaemonStatus{Running: true}}
 	h := newTestHandlers(t, nil, dm)
-	rr := get(h.HandleStatus, "/api/status")
+	rr := get(h.Status, "/api/status")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -668,10 +668,10 @@ func TestHandleStatus_NilStore(t *testing.T) {
 	}
 }
 
-func TestHandleStatus_WithStats(t *testing.T) {
+func TestStatus_WithStats(t *testing.T) {
 	st := &mockStore{stats: &store.Stats{TotalCount: 42, TotalBase: 99999, BaseCurrency: "INR"}}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleStatus, "/api/status")
+	rr := get(h.Status, "/api/status")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -686,9 +686,9 @@ func TestHandleStatus_WithStats(t *testing.T) {
 
 // --- plugin listing ---
 
-func TestHandleListReaders(t *testing.T) {
+func TestListReaders(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.HandleListReaders, "/api/plugins/readers")
+	rr := get(h.ListReaders, "/api/plugins/readers")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -713,7 +713,7 @@ func TestHandleListReaders(t *testing.T) {
 	}
 }
 
-func TestHandleListReaders_NormalizesNilConfigSchema(t *testing.T) {
+func TestListReaders_NormalizesNilConfigSchema(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	registry := plugins.NewRegistry()
 	if err := registry.RegisterReader(&testReaderPlugin{
@@ -725,7 +725,7 @@ func TestHandleListReaders_NormalizesNilConfigSchema(t *testing.T) {
 	}
 	h.registry = registry
 
-	rr := get(h.HandleListReaders, "/api/plugins/readers")
+	rr := get(h.ListReaders, "/api/plugins/readers")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -743,9 +743,9 @@ func TestHandleListReaders_NormalizesNilConfigSchema(t *testing.T) {
 	}
 }
 
-func TestHandleListWriters(t *testing.T) {
+func TestListWriters(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.HandleListWriters, "/api/plugins/writers")
+	rr := get(h.ListWriters, "/api/plugins/writers")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -759,13 +759,13 @@ func TestHandleListWriters(t *testing.T) {
 
 // --- credentials status ---
 
-func TestHandleCredentialsStatus_Missing(t *testing.T) {
+func TestCredentialsStatus_Missing(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	// h.dataDir is t.TempDir() — no credentials file exists there.
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/gmail/credentials/status", nil)
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleCredentialsStatus(rr, req)
+	h.CredentialsStatus(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -777,7 +777,7 @@ func TestHandleCredentialsStatus_Missing(t *testing.T) {
 	}
 }
 
-func TestHandleCredentialsStatus_Present(t *testing.T) {
+func TestCredentialsStatus_Present(t *testing.T) {
 	ms := &mockStore{
 		readerSecrets: map[string][]byte{"gmail": []byte(`{"installed":{}}`)},
 	}
@@ -786,7 +786,7 @@ func TestHandleCredentialsStatus_Present(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/gmail/credentials/status", nil)
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleCredentialsStatus(rr, req)
+	h.CredentialsStatus(rr, req)
 
 	var resp map[string]bool
 	decodeJSON(t, rr.Body.String(), &resp)
@@ -795,26 +795,26 @@ func TestHandleCredentialsStatus_Present(t *testing.T) {
 	}
 }
 
-func TestHandleCredentialsStatus_UnknownReader(t *testing.T) {
+func TestCredentialsStatus_UnknownReader(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/noexist/credentials/status", nil)
 	req.SetPathValue("name", "noexist")
 	rr := httptest.NewRecorder()
-	h.HandleCredentialsStatus(rr, req)
+	h.CredentialsStatus(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
 	}
 }
 
-func TestHandleUploadCredentials_SavesToStore(t *testing.T) {
+func TestUploadCredentials_SavesToStore(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/gmail/credentials", strings.NewReader(`{"installed":{}}`))
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
 
-	h.HandleUploadCredentials(rr, req)
+	h.UploadCredentials(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
@@ -832,7 +832,7 @@ func TestHandleUploadCredentials_SavesToStore(t *testing.T) {
 	}
 }
 
-func TestHandleAuthStart_UsesMetadataScopes(t *testing.T) {
+func TestAuthStart_UsesMetadataScopes(t *testing.T) {
 	const expectedScope = "https://www.googleapis.com/auth/gmail.readonly"
 	secretJSON := `{
 		"installed": {
@@ -860,7 +860,7 @@ func TestHandleAuthStart_UsesMetadataScopes(t *testing.T) {
 	req.SetPathValue("name", "scoped")
 	rr := httptest.NewRecorder()
 
-	h.HandleAuthStart(rr, req)
+	h.AuthStart(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -878,12 +878,12 @@ func TestHandleAuthStart_UsesMetadataScopes(t *testing.T) {
 
 // --- auth status ---
 
-func TestHandleAuthStatus_NoToken(t *testing.T) {
+func TestAuthStatus_NoToken(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/gmail/auth/status", nil)
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleAuthStatus(rr, req)
+	h.AuthStatus(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -895,12 +895,12 @@ func TestHandleAuthStatus_NoToken(t *testing.T) {
 	}
 }
 
-func TestHandleAuthStatus_ConfigReader(t *testing.T) {
+func TestAuthStatus_ConfigReader(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/thunderbird/auth/status", nil)
 	req.SetPathValue("name", "thunderbird")
 	rr := httptest.NewRecorder()
-	h.HandleAuthStatus(rr, req)
+	h.AuthStatus(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -912,7 +912,7 @@ func TestHandleAuthStatus_ConfigReader(t *testing.T) {
 	}
 }
 
-func TestHandleAuthStatus_UsesStoreToken(t *testing.T) {
+func TestAuthStatus_UsesStoreToken(t *testing.T) {
 	ms := &mockStore{
 		readerTokens: map[string][]byte{
 			"gmail": []byte(`{"access_token":"a","token_type":"Bearer","expiry":"2999-01-01T00:00:00Z"}`),
@@ -923,7 +923,7 @@ func TestHandleAuthStatus_UsesStoreToken(t *testing.T) {
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
 
-	h.HandleAuthStatus(rr, req)
+	h.AuthStatus(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -937,12 +937,12 @@ func TestHandleAuthStatus_UsesStoreToken(t *testing.T) {
 
 // --- reader status ---
 
-func TestHandleReaderStatus_Thunderbird_NotConfigured(t *testing.T) {
+func TestReaderStatus_Thunderbird_NotConfigured(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/thunderbird/status", nil)
 	req.SetPathValue("name", "thunderbird")
 	rr := httptest.NewRecorder()
-	h.HandleReaderStatus(rr, req)
+	h.ReaderStatus(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -954,7 +954,7 @@ func TestHandleReaderStatus_Thunderbird_NotConfigured(t *testing.T) {
 	}
 }
 
-func TestHandleReaderStatus_Thunderbird_Configured(t *testing.T) {
+func TestReaderStatus_Thunderbird_Configured(t *testing.T) {
 	ms := &mockStore{
 		readerConfigs: map[string]json.RawMessage{
 			"thunderbird": json.RawMessage(`{"profilePath":"/tmp/tb"}`),
@@ -965,7 +965,7 @@ func TestHandleReaderStatus_Thunderbird_Configured(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/thunderbird/status", nil)
 	req.SetPathValue("name", "thunderbird")
 	rr := httptest.NewRecorder()
-	h.HandleReaderStatus(rr, req)
+	h.ReaderStatus(rr, req)
 
 	var resp map[string]any
 	decodeJSON(t, rr.Body.String(), &resp)
@@ -974,7 +974,7 @@ func TestHandleReaderStatus_Thunderbird_Configured(t *testing.T) {
 	}
 }
 
-func TestHandleSaveReaderConfig_SavesToStore(t *testing.T) {
+func TestSaveReaderConfig_SavesToStore(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(
@@ -986,7 +986,7 @@ func TestHandleSaveReaderConfig_SavesToStore(t *testing.T) {
 	req.SetPathValue("name", "thunderbird")
 	rr := httptest.NewRecorder()
 
-	h.HandleSaveReaderConfig(rr, req)
+	h.SaveReaderConfig(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
@@ -999,7 +999,7 @@ func TestHandleSaveReaderConfig_SavesToStore(t *testing.T) {
 	}
 }
 
-func TestHandleGetReaderConfig_LoadsFromStore(t *testing.T) {
+func TestGetReaderConfig_LoadsFromStore(t *testing.T) {
 	ms := &mockStore{
 		readerConfigs: map[string]json.RawMessage{
 			"thunderbird": json.RawMessage(`{"config":{"mailboxes":"Inbox"}}`),
@@ -1010,7 +1010,7 @@ func TestHandleGetReaderConfig_LoadsFromStore(t *testing.T) {
 	req.SetPathValue("name", "thunderbird")
 	rr := httptest.NewRecorder()
 
-	h.HandleGetReaderConfig(rr, req)
+	h.GetReaderConfig(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
@@ -1020,14 +1020,14 @@ func TestHandleGetReaderConfig_LoadsFromStore(t *testing.T) {
 	}
 }
 
-func TestHandleRevokeToken_DeletesStoreToken(t *testing.T) {
+func TestRevokeToken_DeletesStoreToken(t *testing.T) {
 	ms := &mockStore{readerTokens: map[string][]byte{"gmail": []byte(`{"access_token":"a"}`)}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/readers/gmail/auth/token", nil)
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
 
-	h.HandleRevokeToken(rr, req)
+	h.RevokeToken(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
@@ -1039,18 +1039,18 @@ func TestHandleRevokeToken_DeletesStoreToken(t *testing.T) {
 
 // --- transactions ---
 
-func TestHandleListTransactions_NilStore(t *testing.T) {
+func TestListTransactions_NilStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.HandleListTransactions, "/api/transactions")
+	rr := get(h.ListTransactions, "/api/transactions")
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleListTransactions_Empty(t *testing.T) {
+func TestListTransactions_Empty(t *testing.T) {
 	st := &mockStore{transactions: []store.Transaction{}, listResult: store.TransactionListResult{Total: 0}}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleListTransactions, "/api/transactions?page=1&page_size=10")
+	rr := get(h.ListTransactions, "/api/transactions?page=1&page_size=10")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1069,10 +1069,10 @@ func TestHandleListTransactions_Empty(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_NilSliceReturnsEmptyArray(t *testing.T) {
+func TestListTransactions_NilSliceReturnsEmptyArray(t *testing.T) {
 	st := &mockStore{transactions: nil, listResult: store.TransactionListResult{Total: 0}}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleListTransactions, "/api/transactions?page=1&page_size=10")
+	rr := get(h.ListTransactions, "/api/transactions?page=1&page_size=10")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1088,7 +1088,7 @@ func TestHandleListTransactions_NilSliceReturnsEmptyArray(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_WithResults(t *testing.T) {
+func TestListTransactions_WithResults(t *testing.T) {
 	now := time.Now()
 	st := &mockStore{
 		transactions: []store.Transaction{
@@ -1100,7 +1100,7 @@ func TestHandleListTransactions_WithResults(t *testing.T) {
 		},
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleListTransactions, "/api/transactions")
+	rr := get(h.ListTransactions, "/api/transactions")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1119,29 +1119,29 @@ func TestHandleListTransactions_WithResults(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_StoreError(t *testing.T) {
+func TestListTransactions_StoreError(t *testing.T) {
 	st := &mockStore{listErr: errors.New("db error")}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleListTransactions, "/api/transactions")
+	rr := get(h.ListTransactions, "/api/transactions")
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", rr.Code)
 	}
 }
 
-func TestHandleListTransactions_InvalidControlCharFilter(t *testing.T) {
+func TestListTransactions_InvalidControlCharFilter(t *testing.T) {
 	st := &mockStore{}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleListTransactions, "/api/transactions?currency=%00bad")
+	rr := get(h.ListTransactions, "/api/transactions?currency=%00bad")
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
 
-func TestHandleListTransactions_HugePaginationFallsBackToDefaults(t *testing.T) {
+func TestListTransactions_HugePaginationFallsBackToDefaults(t *testing.T) {
 	st := &mockStore{transactions: []store.Transaction{}, listResult: store.TransactionListResult{Total: 0}}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleListTransactions, "/api/transactions?page=576460752303423488&page_size=999999")
+	rr := get(h.ListTransactions, "/api/transactions?page=576460752303423488&page_size=999999")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1154,7 +1154,7 @@ func TestHandleListTransactions_HugePaginationFallsBackToDefaults(t *testing.T) 
 	}
 }
 
-func TestHandleGetTransaction_Found(t *testing.T) {
+func TestGetTransaction_Found(t *testing.T) {
 	txn := &store.Transaction{ID: "11111111-1111-1111-1111-111111111111", Amount: 500, Currency: "INR", Labels: []string{"food"}}
 	st := &mockStore{getResult: txn}
 	h := newTestHandlers(t, st, &mockDaemon{})
@@ -1162,7 +1162,7 @@ func TestHandleGetTransaction_Found(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/11111111-1111-1111-1111-111111111111", nil)
 	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
 	rr := httptest.NewRecorder()
-	h.HandleGetTransaction(rr, req)
+	h.GetTransaction(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1174,35 +1174,35 @@ func TestHandleGetTransaction_Found(t *testing.T) {
 	}
 }
 
-func TestHandleGetTransaction_NotFound(t *testing.T) {
+func TestGetTransaction_NotFound(t *testing.T) {
 	st := &mockStore{getErr: store.ErrNotFound}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/22222222-2222-2222-2222-222222222222", nil)
 	req.SetPathValue("id", "22222222-2222-2222-2222-222222222222")
 	rr := httptest.NewRecorder()
-	h.HandleGetTransaction(rr, req)
+	h.GetTransaction(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
 	}
 }
 
-func TestHandleGetTransaction_InvalidID(t *testing.T) {
+func TestGetTransaction_InvalidID(t *testing.T) {
 	st := &mockStore{}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/not-a-uuid", nil)
 	req.SetPathValue("id", "not-a-uuid")
 	rr := httptest.NewRecorder()
-	h.HandleGetTransaction(rr, req)
+	h.GetTransaction(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
 
-func TestHandleUpdateTransaction_Success(t *testing.T) {
+func TestUpdateTransaction_Success(t *testing.T) {
 	txn := &store.Transaction{ID: "abc", Description: "Updated", Labels: []string{}}
 	st := &mockStore{getResult: txn}
 	h := newTestHandlers(t, st, &mockDaemon{})
@@ -1211,14 +1211,14 @@ func TestHandleUpdateTransaction_Success(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/transactions/abc", strings.NewReader(body))
 	req.SetPathValue("id", "abc")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateTransaction(rr, req)
+	h.UpdateTransaction(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body=%s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleUpdateTransaction_NotFound(t *testing.T) {
+func TestUpdateTransaction_NotFound(t *testing.T) {
 	st := &mockStore{updateTxErr: store.ErrNotFound}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
@@ -1226,32 +1226,32 @@ func TestHandleUpdateTransaction_NotFound(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/transactions/noexist", strings.NewReader(body))
 	req.SetPathValue("id", "noexist")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateTransaction(rr, req)
+	h.UpdateTransaction(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
 	}
 }
 
-func TestHandleUpdateTransaction_InvalidJSON(t *testing.T) {
+func TestUpdateTransaction_InvalidJSON(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/transactions/abc", strings.NewReader("not-json"))
 	req.SetPathValue("id", "abc")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateTransaction(rr, req)
+	h.UpdateTransaction(rr, req)
 
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", rr.Code)
 	}
 }
 
-func TestHandleListExtractionDiagnostics_DefaultsStatusOpen(t *testing.T) {
+func TestListExtractionDiagnostics_DefaultsStatusOpen(t *testing.T) {
 	st := &mockStore{diagnostics: []store.ExtractionDiagnosticRow{{ID: "diag-1", Status: store.DiagnosticStatusOpen}}}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics", nil)
 	rr := httptest.NewRecorder()
-	h.HandleListExtractionDiagnostics(rr, req)
+	h.ListExtractionDiagnostics(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body=%s)", rr.Code, rr.Body.String())
@@ -1266,13 +1266,13 @@ func TestHandleListExtractionDiagnostics_DefaultsStatusOpen(t *testing.T) {
 	}
 }
 
-func TestHandleListExtractionDiagnostics_StatusAllAndLimit(t *testing.T) {
+func TestListExtractionDiagnostics_StatusAllAndLimit(t *testing.T) {
 	st := &mockStore{}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics?status=all&limit=25", nil)
 	rr := httptest.NewRecorder()
-	h.HandleListExtractionDiagnostics(rr, req)
+	h.ListExtractionDiagnostics(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body=%s)", rr.Code, rr.Body.String())
@@ -1285,38 +1285,38 @@ func TestHandleListExtractionDiagnostics_StatusAllAndLimit(t *testing.T) {
 	}
 }
 
-func TestHandleListExtractionDiagnostics_InvalidStatus(t *testing.T) {
+func TestListExtractionDiagnostics_InvalidStatus(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics?status=pending", nil)
 	rr := httptest.NewRecorder()
-	h.HandleListExtractionDiagnostics(rr, req)
+	h.ListExtractionDiagnostics(rr, req)
 
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", rr.Code)
 	}
 }
 
-func TestHandleListExtractionDiagnostics_InvalidLimit(t *testing.T) {
+func TestListExtractionDiagnostics_InvalidLimit(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics?limit=bad", nil)
 	rr := httptest.NewRecorder()
-	h.HandleListExtractionDiagnostics(rr, req)
+	h.ListExtractionDiagnostics(rr, req)
 
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", rr.Code)
 	}
 }
 
-func TestHandleGetExtractionDiagnostic_Found(t *testing.T) {
+func TestGetExtractionDiagnostic_Found(t *testing.T) {
 	row := &store.ExtractionDiagnosticRow{ID: "11111111-1111-1111-1111-111111111111", Status: store.DiagnosticStatusOpen}
 	h := newTestHandlers(t, &mockStore{diagnosticResult: row}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics/11111111-1111-1111-1111-111111111111", nil)
 	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
 	rr := httptest.NewRecorder()
-	h.HandleGetExtractionDiagnostic(rr, req)
+	h.GetExtractionDiagnostic(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body=%s)", rr.Code, rr.Body.String())
@@ -1328,46 +1328,46 @@ func TestHandleGetExtractionDiagnostic_Found(t *testing.T) {
 	}
 }
 
-func TestHandleGetExtractionDiagnostic_NotFound(t *testing.T) {
+func TestGetExtractionDiagnostic_NotFound(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{diagnosticErr: store.ErrNotFound}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics/22222222-2222-2222-2222-222222222222", nil)
 	req.SetPathValue("id", "22222222-2222-2222-2222-222222222222")
 	rr := httptest.NewRecorder()
-	h.HandleGetExtractionDiagnostic(rr, req)
+	h.GetExtractionDiagnostic(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
 	}
 }
 
-func TestHandleGetExtractionDiagnostic_InvalidID(t *testing.T) {
+func TestGetExtractionDiagnostic_InvalidID(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{diagnosticErr: errors.New("store should not be called")}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics/not-a-uuid", nil)
 	req.SetPathValue("id", "not-a-uuid")
 	rr := httptest.NewRecorder()
-	h.HandleGetExtractionDiagnostic(rr, req)
+	h.GetExtractionDiagnostic(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
 
-func TestHandleGetExtractionDiagnostic_NilStore(t *testing.T) {
+func TestGetExtractionDiagnostic_NilStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics/11111111-1111-1111-1111-111111111111", nil)
 	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
 	rr := httptest.NewRecorder()
-	h.HandleGetExtractionDiagnostic(rr, req)
+	h.GetExtractionDiagnostic(rr, req)
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleUpdateExtractionDiagnosticStatus_InvalidStatus(t *testing.T) {
+func TestUpdateExtractionDiagnosticStatus_InvalidStatus(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(
@@ -1378,14 +1378,14 @@ func TestHandleUpdateExtractionDiagnosticStatus_InvalidStatus(t *testing.T) {
 	)
 	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateExtractionDiagnosticStatus(rr, req)
+	h.UpdateExtractionDiagnosticStatus(rr, req)
 
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", rr.Code)
 	}
 }
 
-func TestHandleUpdateExtractionDiagnosticStatus_NotFound(t *testing.T) {
+func TestUpdateExtractionDiagnosticStatus_NotFound(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{diagnosticErr: store.ErrNotFound}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(
@@ -1396,14 +1396,14 @@ func TestHandleUpdateExtractionDiagnosticStatus_NotFound(t *testing.T) {
 	)
 	req.SetPathValue("id", "33333333-3333-3333-3333-333333333333")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateExtractionDiagnosticStatus(rr, req)
+	h.UpdateExtractionDiagnosticStatus(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
 	}
 }
 
-func TestHandleUpdateExtractionDiagnosticStatus_InvalidID(t *testing.T) {
+func TestUpdateExtractionDiagnosticStatus_InvalidID(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{diagnosticErr: errors.New("store should not be called")}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(
@@ -1414,14 +1414,14 @@ func TestHandleUpdateExtractionDiagnosticStatus_InvalidID(t *testing.T) {
 	)
 	req.SetPathValue("id", "not-a-uuid")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateExtractionDiagnosticStatus(rr, req)
+	h.UpdateExtractionDiagnosticStatus(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
 
-func TestHandleUpdateExtractionDiagnosticStatus_Conflict(t *testing.T) {
+func TestUpdateExtractionDiagnosticStatus_Conflict(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{diagnosticErr: store.ErrDiagnosticConflict}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(
@@ -1432,14 +1432,14 @@ func TestHandleUpdateExtractionDiagnosticStatus_Conflict(t *testing.T) {
 	)
 	req.SetPathValue("id", "44444444-4444-4444-4444-444444444444")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateExtractionDiagnosticStatus(rr, req)
+	h.UpdateExtractionDiagnosticStatus(rr, req)
 
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d", rr.Code)
 	}
 }
 
-func TestHandleUpdateExtractionDiagnosticStatus_NilStore(t *testing.T) {
+func TestUpdateExtractionDiagnosticStatus_NilStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(
@@ -1450,105 +1450,105 @@ func TestHandleUpdateExtractionDiagnosticStatus_NilStore(t *testing.T) {
 	)
 	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateExtractionDiagnosticStatus(rr, req)
+	h.UpdateExtractionDiagnosticStatus(rr, req)
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleListExtractionDiagnostics_NilStore(t *testing.T) {
+func TestListExtractionDiagnostics_NilStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics", nil)
 	rr := httptest.NewRecorder()
-	h.HandleListExtractionDiagnostics(rr, req)
+	h.ListExtractionDiagnostics(rr, req)
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleAddLabels_Success(t *testing.T) {
+func TestAddLabels_Success(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := `{"labels":["food","work"]}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/transactions/abc/labels", strings.NewReader(body))
 	req.SetPathValue("id", "abc")
 	rr := httptest.NewRecorder()
-	h.HandleAddLabels(rr, req)
+	h.AddLabels(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 }
 
-func TestHandleAddLabels_InvalidJSON(t *testing.T) {
+func TestAddLabels_InvalidJSON(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/transactions/abc/labels", strings.NewReader("bad"))
 	req.SetPathValue("id", "abc")
 	rr := httptest.NewRecorder()
-	h.HandleAddLabels(rr, req)
+	h.AddLabels(rr, req)
 
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", rr.Code)
 	}
 }
 
-func TestHandleAddLabels_BatchSuccess(t *testing.T) {
+func TestAddLabels_BatchSuccess(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	body := `{"labels":["food","work","recurring"]}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/transactions/abc/labels", strings.NewReader(body))
 	req.SetPathValue("id", "abc")
 	rr := httptest.NewRecorder()
-	h.HandleAddLabels(rr, req)
+	h.AddLabels(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleAddLabels_StoreError_Returns500(t *testing.T) {
+func TestAddLabels_StoreError_Returns500(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{addLabelsErr: errors.New("db error")}, &mockDaemon{})
 
 	body := `{"labels":["food"]}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/transactions/abc/labels", strings.NewReader(body))
 	req.SetPathValue("id", "abc")
 	rr := httptest.NewRecorder()
-	h.HandleAddLabels(rr, req)
+	h.AddLabels(rr, req)
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", rr.Code)
 	}
 }
 
-func TestHandleRemoveLabel_Success(t *testing.T) {
+func TestRemoveLabel_Success(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/transactions/abc/labels/food", nil)
 	req.SetPathValue("id", "abc")
 	req.SetPathValue("label", "food")
 	rr := httptest.NewRecorder()
-	h.HandleRemoveLabel(rr, req)
+	h.RemoveLabel(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 }
 
-func TestHandleRemoveLabel_NotFound(t *testing.T) {
+func TestRemoveLabel_NotFound(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{removeLblErr: store.ErrNotFound}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/transactions/abc/labels/missing", nil)
 	req.SetPathValue("id", "abc")
 	req.SetPathValue("label", "missing")
 	rr := httptest.NewRecorder()
-	h.HandleRemoveLabel(rr, req)
+	h.RemoveLabel(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
 	}
 }
 
-func TestHandleSearchTransactions_Basic(t *testing.T) {
+func TestSearchTransactions_Basic(t *testing.T) {
 	st := &mockStore{
 		searchResult: []store.Transaction{{ID: "x", MerchantInfo: "Zomato", Labels: []string{}}},
 		searchListResult: store.TransactionListResult{
@@ -1557,7 +1557,7 @@ func TestHandleSearchTransactions_Basic(t *testing.T) {
 		},
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleSearchTransactions, "/api/transactions/search?q=zomato")
+	rr := get(h.SearchTransactions, "/api/transactions/search?q=zomato")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1578,13 +1578,13 @@ func TestHandleSearchTransactions_Basic(t *testing.T) {
 	}
 }
 
-func TestHandleSearchTransactions_EmptyArray(t *testing.T) {
+func TestSearchTransactions_EmptyArray(t *testing.T) {
 	st := &mockStore{
 		searchResult:     []store.Transaction{},
 		searchListResult: store.TransactionListResult{Total: 0},
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleSearchTransactions, "/api/transactions/search?q=zomato")
+	rr := get(h.SearchTransactions, "/api/transactions/search?q=zomato")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1600,13 +1600,13 @@ func TestHandleSearchTransactions_EmptyArray(t *testing.T) {
 	}
 }
 
-func TestHandleSearchTransactions_NilSliceReturnsEmptyArray(t *testing.T) {
+func TestSearchTransactions_NilSliceReturnsEmptyArray(t *testing.T) {
 	st := &mockStore{
 		searchResult:     nil,
 		searchListResult: store.TransactionListResult{Total: 0},
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleSearchTransactions, "/api/transactions/search?q=zomato")
+	rr := get(h.SearchTransactions, "/api/transactions/search?q=zomato")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1622,22 +1622,22 @@ func TestHandleSearchTransactions_NilSliceReturnsEmptyArray(t *testing.T) {
 	}
 }
 
-func TestHandleSearchTransactions_NilStore(t *testing.T) {
+func TestSearchTransactions_NilStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.HandleSearchTransactions, "/api/transactions/search?q=foo")
+	rr := get(h.SearchTransactions, "/api/transactions/search?q=foo")
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleSearchTransactions_MutedAndIndividualFlags(t *testing.T) {
+func TestSearchTransactions_MutedAndIndividualFlags(t *testing.T) {
 	st := &mockStore{
 		searchResult:     []store.Transaction{},
 		searchListResult: store.TransactionListResult{Total: 0},
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
-	rr := get(h.HandleSearchTransactions, "/api/transactions/search?q=zomato&muted_only=1&individual_only=1")
+	rr := get(h.SearchTransactions, "/api/transactions/search?q=zomato&muted_only=1&individual_only=1")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1650,23 +1650,23 @@ func TestHandleSearchTransactions_MutedAndIndividualFlags(t *testing.T) {
 	}
 }
 
-func TestHandleSearchTransactions_InvalidControlCharQuery(t *testing.T) {
+func TestSearchTransactions_InvalidControlCharQuery(t *testing.T) {
 	st := &mockStore{}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleSearchTransactions, "/api/transactions/search?q=%00bad")
+	rr := get(h.SearchTransactions, "/api/transactions/search?q=%00bad")
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
 
-func TestHandleSearchTransactions_HugePaginationFallsBackToDefaults(t *testing.T) {
+func TestSearchTransactions_HugePaginationFallsBackToDefaults(t *testing.T) {
 	st := &mockStore{
 		searchResult:     []store.Transaction{},
 		searchListResult: store.TransactionListResult{Total: 0},
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleSearchTransactions, "/api/transactions/search?q=test&page=576460752303423488&page_size=999999")
+	rr := get(h.SearchTransactions, "/api/transactions/search?q=test&page=576460752303423488&page_size=999999")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1725,19 +1725,19 @@ func TestGenerateState_ContainsReaderName(t *testing.T) {
 
 // --- OAuth state TTL ---
 
-func TestHandleAuthCallback_RejectsUnknownState(t *testing.T) {
+func TestAuthCallback_RejectsUnknownState(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/auth/callback?state=doesnotexist&code=xyz", nil)
 	rr := httptest.NewRecorder()
-	h.HandleAuthCallback(rr, req)
+	h.AuthCallback(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for unknown state, got %d", rr.Code)
 	}
 }
 
-func TestHandleAuthCallback_RejectsExpiredState(t *testing.T) {
+func TestAuthCallback_RejectsExpiredState(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	// Inject an already-expired entry directly into the map.
@@ -1751,7 +1751,7 @@ func TestHandleAuthCallback_RejectsExpiredState(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/auth/callback?state="+expiredState+"&code=xyz", nil)
 	rr := httptest.NewRecorder()
-	h.HandleAuthCallback(rr, req)
+	h.AuthCallback(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for expired state, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -1760,12 +1760,12 @@ func TestHandleAuthCallback_RejectsExpiredState(t *testing.T) {
 
 // --- app config / base currency ---
 
-func TestHandleGetBaseCurrency_DefaultsToConfig(t *testing.T) {
+func TestGetBaseCurrency_DefaultsToConfig(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/base-currency", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetBaseCurrency(rr, req)
+	h.GetBaseCurrency(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -1777,13 +1777,13 @@ func TestHandleGetBaseCurrency_DefaultsToConfig(t *testing.T) {
 	}
 }
 
-func TestHandleGetBaseCurrency_FromDB(t *testing.T) {
+func TestGetBaseCurrency_FromDB(t *testing.T) {
 	ms := &mockStore{appConfig: map[string]string{"base_currency": "USD"}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/base-currency", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetBaseCurrency(rr, req)
+	h.GetBaseCurrency(rr, req)
 
 	var resp map[string]string
 	decodeJSON(t, rr.Body.String(), &resp)
@@ -1792,12 +1792,12 @@ func TestHandleGetBaseCurrency_FromDB(t *testing.T) {
 	}
 }
 
-func TestHandleGetSetupStatusRequiresMissingPreferences(t *testing.T) {
+func TestGetSetupStatusRequiresMissingPreferences(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{appConfig: map[string]string{"scan_interval": "60"}}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/setup-status", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetSetupStatus(rr, req)
+	h.GetSetupStatus(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body %s", rr.Code, rr.Body.String())
@@ -1818,7 +1818,7 @@ func TestHandleGetSetupStatusRequiresMissingPreferences(t *testing.T) {
 	}
 }
 
-func TestHandleGetSetupStatusCompleteWhenPreferencesExist(t *testing.T) {
+func TestGetSetupStatusCompleteWhenPreferencesExist(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{appConfig: map[string]string{
 		"base_currency":   "USD",
 		"app.timezone":    "America/New_York",
@@ -1827,7 +1827,7 @@ func TestHandleGetSetupStatusCompleteWhenPreferencesExist(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/setup-status", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetSetupStatus(rr, req)
+	h.GetSetupStatus(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body %s", rr.Code, rr.Body.String())
@@ -1847,7 +1847,7 @@ func TestHandleGetSetupStatusCompleteWhenPreferencesExist(t *testing.T) {
 	}
 }
 
-func TestHandleGetDashboardData_Success(t *testing.T) {
+func TestGetDashboardData_Success(t *testing.T) {
 	ms := &mockStore{
 		dashboardData: &store.DashboardData{
 			CurrentMonth: store.DashboardSection{
@@ -1882,7 +1882,7 @@ func TestHandleGetDashboardData_Success(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/dashboard", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetDashboardData(rr, req)
+	h.GetDashboardData(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -1898,7 +1898,7 @@ func TestHandleGetDashboardData_Success(t *testing.T) {
 	}
 }
 
-func TestHandleGetMonthlyBreakdown_InvalidDimension(t *testing.T) {
+func TestGetMonthlyBreakdown_InvalidDimension(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(
@@ -1908,21 +1908,21 @@ func TestHandleGetMonthlyBreakdown_InvalidDimension(t *testing.T) {
 		nil,
 	)
 	rr := httptest.NewRecorder()
-	h.HandleGetLabelMonthlySpend(rr, req)
+	h.GetLabelMonthlySpend(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
 
-func TestHandleSetBaseCurrency_Success(t *testing.T) {
+func TestSetBaseCurrency_Success(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 
 	body := strings.NewReader(`{"base_currency":"usd"}`)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/config/base-currency", body)
 	rr := httptest.NewRecorder()
-	h.HandleSetBaseCurrency(rr, req)
+	h.SetBaseCurrency(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -1937,46 +1937,46 @@ func TestHandleSetBaseCurrency_Success(t *testing.T) {
 	}
 }
 
-func TestHandleSetBaseCurrency_InvalidCode(t *testing.T) {
+func TestSetBaseCurrency_InvalidCode(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	for _, tc := range []string{`{"base_currency":"US"}`, `{"base_currency":"USDA"}`, `{"base_currency":"12A"}`} {
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/config/base-currency", strings.NewReader(tc))
 		rr := httptest.NewRecorder()
-		h.HandleSetBaseCurrency(rr, req)
+		h.SetBaseCurrency(rr, req)
 		if rr.Code != http.StatusBadRequest {
 			t.Errorf("input %s: expected 400, got %d", tc, rr.Code)
 		}
 	}
 }
 
-func TestHandleSetBaseCurrency_NoStore(t *testing.T) {
+func TestSetBaseCurrency_NoStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/config/base-currency", strings.NewReader(`{"base_currency":"USD"}`))
 	rr := httptest.NewRecorder()
-	h.HandleSetBaseCurrency(rr, req)
+	h.SetBaseCurrency(rr, req)
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleGetFacets_NoStore(t *testing.T) {
+func TestGetFacets_NoStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/facets", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetFacets(rr, req)
+	h.GetFacets(rr, req)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleGetFacets_ReturnsEmptySlices(t *testing.T) {
+func TestGetFacets_ReturnsEmptySlices(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/facets", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetFacets(rr, req)
+	h.GetFacets(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2006,7 +2006,7 @@ func TestHandleGetFacets_ReturnsEmptySlices(t *testing.T) {
 	}
 }
 
-func TestHandleGetFacets_ReturnsLabelCounts(t *testing.T) {
+func TestGetFacets_ReturnsLabelCounts(t *testing.T) {
 	h := newTestHandlers(
 		t,
 		&mockStore{facets: &store.Facets{Labels: []string{"Food"}, LabelCounts: map[string]int{"Food": 3}}},
@@ -2015,7 +2015,7 @@ func TestHandleGetFacets_ReturnsLabelCounts(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/facets", nil)
 	rr := httptest.NewRecorder()
 
-	h.HandleGetFacets(rr, req)
+	h.GetFacets(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -2029,11 +2029,11 @@ func TestHandleGetFacets_ReturnsLabelCounts(t *testing.T) {
 	}
 }
 
-func TestHandleGetFacets_StoreError(t *testing.T) {
+func TestGetFacets_StoreError(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{getFacetsErr: errors.New("db error")}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/facets", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetFacets(rr, req)
+	h.GetFacets(rr, req)
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", rr.Code)
 	}
@@ -2041,18 +2041,18 @@ func TestHandleGetFacets_StoreError(t *testing.T) {
 
 // --- labels ---
 
-func TestHandleListLabels_NoStore(t *testing.T) {
+func TestListLabels_NoStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.HandleListLabels, "/api/config/labels")
+	rr := get(h.ListLabels, "/api/config/labels")
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleListLabels_Success(t *testing.T) {
+func TestListLabels_Success(t *testing.T) {
 	ms := &mockStore{labels: []store.Label{{Name: "food", Color: "#f59e0b"}}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
-	rr := get(h.HandleListLabels, "/api/config/labels")
+	rr := get(h.ListLabels, "/api/config/labels")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2063,12 +2063,12 @@ func TestHandleListLabels_Success(t *testing.T) {
 	}
 }
 
-func TestHandleCreateLabel_Success(t *testing.T) {
+func TestCreateLabel_Success(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := strings.NewReader(`{"name":"groceries","color":"#aabbcc"}`)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/config/labels", body)
 	rr := httptest.NewRecorder()
-	h.HandleCreateLabel(rr, req)
+	h.CreateLabel(rr, req)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -2079,7 +2079,7 @@ func TestHandleCreateLabel_Success(t *testing.T) {
 	}
 }
 
-func TestHandleDeleteLabel_NotFound(t *testing.T) {
+func TestDeleteLabel_NotFound(t *testing.T) {
 	ms := &mockStore{labelsErr: store.ErrNotFound}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/config/labels/missing", nil)
@@ -2088,13 +2088,13 @@ func TestHandleDeleteLabel_NotFound(t *testing.T) {
 	// DeleteLabel returns the labelsErr directly; since it's ErrNotFound the handler
 	// logs and returns 500 (DeleteLabel has no ErrNotFound branch in the handler).
 	// The store just returns the error; handler writes 500. Verify non-204.
-	h.HandleDeleteLabel(rr, req)
+	h.DeleteLabel(rr, req)
 	if rr.Code == http.StatusNoContent {
 		t.Fatalf("expected non-204 on error, got 204")
 	}
 }
 
-func TestHandleDeleteLabel_RemoveFromTransactionsOption(t *testing.T) {
+func TestDeleteLabel_RemoveFromTransactionsOption(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 
@@ -2103,7 +2103,7 @@ func TestHandleDeleteLabel_RemoveFromTransactionsOption(t *testing.T) {
 	req.SetPathValue("name", "food")
 	rr := httptest.NewRecorder()
 
-	h.HandleDeleteLabel(rr, req)
+	h.DeleteLabel(rr, req)
 
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", rr.Code)
@@ -2113,7 +2113,7 @@ func TestHandleDeleteLabel_RemoveFromTransactionsOption(t *testing.T) {
 	}
 }
 
-func TestHandleDeleteLabel_RemoveFromTransactionsQueryOption(t *testing.T) {
+func TestDeleteLabel_RemoveFromTransactionsQueryOption(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 
@@ -2126,7 +2126,7 @@ func TestHandleDeleteLabel_RemoveFromTransactionsQueryOption(t *testing.T) {
 	req.SetPathValue("name", "food")
 	rr := httptest.NewRecorder()
 
-	h.HandleDeleteLabel(rr, req)
+	h.DeleteLabel(rr, req)
 
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", rr.Code)
@@ -2138,10 +2138,10 @@ func TestHandleDeleteLabel_RemoveFromTransactionsQueryOption(t *testing.T) {
 
 // --- categories ---
 
-func TestHandleListCategories_Success(t *testing.T) {
+func TestListCategories_Success(t *testing.T) {
 	ms := &mockStore{categories: []store.Category{{Name: "food & dining", IsDefault: true}}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
-	rr := get(h.HandleListCategories, "/api/config/categories")
+	rr := get(h.ListCategories, "/api/config/categories")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2152,22 +2152,22 @@ func TestHandleListCategories_Success(t *testing.T) {
 	}
 }
 
-func TestHandleDeleteCategory_DefaultRejected(t *testing.T) {
+func TestDeleteCategory_DefaultRejected(t *testing.T) {
 	ms := &mockStore{catsErr: fmt.Errorf("cannot delete default category \"food\"")}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/config/categories/food", nil)
 	req.SetPathValue("name", "food")
 	rr := httptest.NewRecorder()
-	h.HandleDeleteCategory(rr, req)
+	h.DeleteCategory(rr, req)
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleGetCategoryMappings_Success(t *testing.T) {
+func TestGetCategoryMappings_Success(t *testing.T) {
 	ms := &mockStore{categoryMappings: map[string][]string{"Food": {"swiggy", "zomato"}}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
-	rr := get(h.HandleGetCategoryMappings, "/api/config/categories/mappings")
+	rr := get(h.GetCategoryMappings, "/api/config/categories/mappings")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2178,14 +2178,14 @@ func TestHandleGetCategoryMappings_Success(t *testing.T) {
 	}
 }
 
-func TestHandleApplyCategoryByMerchant_Success(t *testing.T) {
+func TestApplyCategoryByMerchant_Success(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := strings.NewReader(`{"merchant_pattern":"swiggy"}`)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/config/categories/Food/apply", body)
 	req.SetPathValue("name", "Food")
 	rr := httptest.NewRecorder()
 
-	h.HandleApplyCategoryByMerchant(rr, req)
+	h.ApplyCategoryByMerchant(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2197,7 +2197,7 @@ func TestHandleApplyCategoryByMerchant_Success(t *testing.T) {
 	}
 }
 
-func TestHandleDeleteCategory_RemoveFromTransactionsOption(t *testing.T) {
+func TestDeleteCategory_RemoveFromTransactionsOption(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	body := strings.NewReader(`{"remove_from_transactions":true}`)
@@ -2205,7 +2205,7 @@ func TestHandleDeleteCategory_RemoveFromTransactionsOption(t *testing.T) {
 	req.SetPathValue("name", "Food")
 	rr := httptest.NewRecorder()
 
-	h.HandleDeleteCategory(rr, req)
+	h.DeleteCategory(rr, req)
 
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", rr.Code)
@@ -2215,13 +2215,13 @@ func TestHandleDeleteCategory_RemoveFromTransactionsOption(t *testing.T) {
 	}
 }
 
-func TestHandleExportCategories_IncludesMerchants(t *testing.T) {
+func TestExportCategories_IncludesMerchants(t *testing.T) {
 	ms := &mockStore{
 		categories:       []store.Category{{Name: "Food"}},
 		categoryMappings: map[string][]string{"Food": {"swiggy"}},
 	}
 	h := newTestHandlers(t, ms, &mockDaemon{})
-	rr := get(h.HandleExportCategories, "/api/config/categories/export")
+	rr := get(h.ExportCategories, "/api/config/categories/export")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2238,10 +2238,10 @@ func TestHandleExportCategories_IncludesMerchants(t *testing.T) {
 
 // --- buckets ---
 
-func TestHandleListBuckets_Success(t *testing.T) {
+func TestListBuckets_Success(t *testing.T) {
 	ms := &mockStore{buckets: []store.Bucket{{Name: "needs", IsDefault: true}}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
-	rr := get(h.HandleListBuckets, "/api/config/buckets")
+	rr := get(h.ListBuckets, "/api/config/buckets")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2252,10 +2252,10 @@ func TestHandleListBuckets_Success(t *testing.T) {
 	}
 }
 
-func TestHandleGetBucketMappings_Success(t *testing.T) {
+func TestGetBucketMappings_Success(t *testing.T) {
 	ms := &mockStore{bucketMappings: map[string][]string{"Needs": {"rent"}}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
-	rr := get(h.HandleGetBucketMappings, "/api/config/buckets/mappings")
+	rr := get(h.GetBucketMappings, "/api/config/buckets/mappings")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2266,14 +2266,14 @@ func TestHandleGetBucketMappings_Success(t *testing.T) {
 	}
 }
 
-func TestHandleApplyBucketByMerchant_Success(t *testing.T) {
+func TestApplyBucketByMerchant_Success(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := strings.NewReader(`{"merchant_pattern":"rent"}`)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/config/buckets/Needs/apply", body)
 	req.SetPathValue("name", "Needs")
 	rr := httptest.NewRecorder()
 
-	h.HandleApplyBucketByMerchant(rr, req)
+	h.ApplyBucketByMerchant(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2285,7 +2285,7 @@ func TestHandleApplyBucketByMerchant_Success(t *testing.T) {
 	}
 }
 
-func TestHandleDeleteBucket_RemoveFromTransactionsOption(t *testing.T) {
+func TestDeleteBucket_RemoveFromTransactionsOption(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	body := strings.NewReader(`{"remove_from_transactions":true}`)
@@ -2293,7 +2293,7 @@ func TestHandleDeleteBucket_RemoveFromTransactionsOption(t *testing.T) {
 	req.SetPathValue("name", "Needs")
 	rr := httptest.NewRecorder()
 
-	h.HandleDeleteBucket(rr, req)
+	h.DeleteBucket(rr, req)
 
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", rr.Code)
@@ -2303,13 +2303,13 @@ func TestHandleDeleteBucket_RemoveFromTransactionsOption(t *testing.T) {
 	}
 }
 
-func TestHandleExportBuckets_IncludesMerchants(t *testing.T) {
+func TestExportBuckets_IncludesMerchants(t *testing.T) {
 	ms := &mockStore{
 		buckets:        []store.Bucket{{Name: "Needs"}},
 		bucketMappings: map[string][]string{"Needs": {"rent"}},
 	}
 	h := newTestHandlers(t, ms, &mockDaemon{})
-	rr := get(h.HandleExportBuckets, "/api/config/buckets/export")
+	rr := get(h.ExportBuckets, "/api/config/buckets/export")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2326,7 +2326,7 @@ func TestHandleExportBuckets_IncludesMerchants(t *testing.T) {
 
 // --- extended update transaction ---
 
-func TestHandleUpdateTransaction_InvalidCategory(t *testing.T) {
+func TestUpdateTransaction_InvalidCategory(t *testing.T) {
 	// Store returns empty category list, so any category name is invalid.
 	ms := &mockStore{categories: []store.Category{}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
@@ -2334,7 +2334,7 @@ func TestHandleUpdateTransaction_InvalidCategory(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/transactions/abc", body)
 	req.SetPathValue("id", "abc")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateTransaction(rr, req)
+	h.UpdateTransaction(rr, req)
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -2342,12 +2342,12 @@ func TestHandleUpdateTransaction_InvalidCategory(t *testing.T) {
 
 // --- scan interval ---
 
-func TestHandleGetScanInterval_Default(t *testing.T) {
+func TestGetScanInterval_Default(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/scan-interval", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetScanInterval(rr, req)
+	h.GetScanInterval(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -2359,14 +2359,14 @@ func TestHandleGetScanInterval_Default(t *testing.T) {
 	}
 }
 
-func TestHandleSetScanInterval_Valid(t *testing.T) {
+func TestSetScanInterval_Valid(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 
 	body := strings.NewReader(`{"scan_interval":"120"}`)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/config/scan-interval", body)
 	rr := httptest.NewRecorder()
-	h.HandleSetScanInterval(rr, req)
+	h.SetScanInterval(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2381,40 +2381,40 @@ func TestHandleSetScanInterval_Valid(t *testing.T) {
 	}
 }
 
-func TestHandleSetScanInterval_TooLow(t *testing.T) {
+func TestSetScanInterval_TooLow(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	body := strings.NewReader(`{"scan_interval":"5"}`)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/config/scan-interval", body)
 	rr := httptest.NewRecorder()
-	h.HandleSetScanInterval(rr, req)
+	h.SetScanInterval(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleSetScanInterval_TooHigh(t *testing.T) {
+func TestSetScanInterval_TooHigh(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	body := strings.NewReader(`{"scan_interval":"9999"}`)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/config/scan-interval", body)
 	rr := httptest.NewRecorder()
-	h.HandleSetScanInterval(rr, req)
+	h.SetScanInterval(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleGetReaderCheckpoint_EmptyValueReturnsNull(t *testing.T) {
+func TestGetReaderCheckpoint_EmptyValueReturnsNull(t *testing.T) {
 	ms := &mockStore{appConfig: map[string]string{"reader.gmail.last_scan_at": ""}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/readers/gmail/checkpoint", nil)
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleGetReaderCheckpoint(rr, req)
+	h.GetReaderCheckpoint(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -2428,7 +2428,7 @@ func TestHandleGetReaderCheckpoint_EmptyValueReturnsNull(t *testing.T) {
 
 // --- heatmap ---
 
-func TestHandleGetHeatmap_Success(t *testing.T) {
+func TestGetHeatmap_Success(t *testing.T) {
 	ms := &mockStore{
 		heatmapData: &store.HeatmapData{
 			ByWeekdayHour: []store.WeekdayHourBucket{
@@ -2443,7 +2443,7 @@ func TestHandleGetHeatmap_Success(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/heatmap", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetHeatmap(rr, req)
+	h.GetHeatmap(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2461,32 +2461,32 @@ func TestHandleGetHeatmap_Success(t *testing.T) {
 	}
 }
 
-func TestHandleGetHeatmap_StoreError_Returns500(t *testing.T) {
+func TestGetHeatmap_StoreError_Returns500(t *testing.T) {
 	ms := &mockStore{heatmapErr: errors.New("db connection lost")}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/heatmap", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetHeatmap(rr, req)
+	h.GetHeatmap(rr, req)
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleGetHeatmap_NoStore_Returns503(t *testing.T) {
+func TestGetHeatmap_NoStore_Returns503(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/heatmap", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetHeatmap(rr, req)
+	h.GetHeatmap(rr, req)
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleGetHeatmap_WithFromTo_Returns200(t *testing.T) {
+func TestGetHeatmap_WithFromTo_Returns200(t *testing.T) {
 	ms := &mockStore{
 		heatmapData: &store.HeatmapData{
 			ByWeekdayHour: []store.WeekdayHourBucket{{Weekday: 0, Hour: 10, Amount: 100, Count: 1}},
@@ -2501,7 +2501,7 @@ func TestHandleGetHeatmap_WithFromTo_Returns200(t *testing.T) {
 		nil,
 	)
 	rr := httptest.NewRecorder()
-	h.HandleGetHeatmap(rr, req)
+	h.GetHeatmap(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2513,7 +2513,7 @@ func TestHandleGetHeatmap_WithFromTo_Returns200(t *testing.T) {
 	}
 }
 
-func TestHandleGetHeatmap_InvalidFrom_Returns400(t *testing.T) {
+func TestGetHeatmap_InvalidFrom_Returns400(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(
@@ -2522,14 +2522,14 @@ func TestHandleGetHeatmap_InvalidFrom_Returns400(t *testing.T) {
 		nil,
 	)
 	rr := httptest.NewRecorder()
-	h.HandleGetHeatmap(rr, req)
+	h.GetHeatmap(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleGetAnnualHeatmap_Success(t *testing.T) {
+func TestGetAnnualHeatmap_Success(t *testing.T) {
 	ms := &mockStore{
 		annualData: []store.DailyBucket{
 			{Date: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), Amount: 1500.0, Count: 3},
@@ -2539,7 +2539,7 @@ func TestHandleGetAnnualHeatmap_Success(t *testing.T) {
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/heatmap/annual?year=2026", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetAnnualHeatmap(rr, req)
+	h.GetAnnualHeatmap(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2560,25 +2560,25 @@ func TestHandleGetAnnualHeatmap_Success(t *testing.T) {
 	}
 }
 
-func TestHandleGetAnnualHeatmap_StoreError_Returns500(t *testing.T) {
+func TestGetAnnualHeatmap_StoreError_Returns500(t *testing.T) {
 	ms := &mockStore{annualErr: errors.New("db connection lost")}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/heatmap/annual?year=2026", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetAnnualHeatmap(rr, req)
+	h.GetAnnualHeatmap(rr, req)
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleGetAnnualHeatmap_NoStore_Returns503(t *testing.T) {
+func TestGetAnnualHeatmap_NoStore_Returns503(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/heatmap/annual?year=2026", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetAnnualHeatmap(rr, req)
+	h.GetAnnualHeatmap(rr, req)
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2595,12 +2595,12 @@ const validRuleBody = `{
 	"source":{"type":"Credit Card","label":"Example Credit Card","bank":"Example Bank"}
 }`
 
-func TestHandleListRules_Success(t *testing.T) {
+func TestListRules_Success(t *testing.T) {
 	ms := &mockStore{rules: []store.RuleRow{{ID: "1", Name: "test", AmountRegex: `\d+`, MerchantRegex: `.+`}}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/rules", nil)
 	rr := httptest.NewRecorder()
-	h.HandleListRules(rr, req)
+	h.ListRules(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -2611,7 +2611,7 @@ func TestHandleListRules_Success(t *testing.T) {
 	}
 }
 
-func TestHandleListRules_ReturnsSourceObjectAndSenderEmails(t *testing.T) {
+func TestListRules_ReturnsSourceObjectAndSenderEmails(t *testing.T) {
 	ms := &mockStore{rules: []store.RuleRow{{
 		ID:              "1",
 		Name:            "HDFC Credit Card",
@@ -2627,7 +2627,7 @@ func TestHandleListRules_ReturnsSourceObjectAndSenderEmails(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/rules", nil)
 	rr := httptest.NewRecorder()
 
-	h.HandleListRules(rr, req)
+	h.ListRules(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2649,27 +2649,27 @@ func TestHandleListRules_ReturnsSourceObjectAndSenderEmails(t *testing.T) {
 	}
 }
 
-func TestHandleListRules_NilStore_Returns503(t *testing.T) {
+func TestListRules_NilStore_Returns503(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/rules", nil)
 	rr := httptest.NewRecorder()
-	h.HandleListRules(rr, req)
+	h.ListRules(rr, req)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
-func TestHandleCreateRule_Success(t *testing.T) {
+func TestCreateRule_Success(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules", strings.NewReader(validRuleBody))
 	rr := httptest.NewRecorder()
-	h.HandleCreateRule(rr, req)
+	h.CreateRule(rr, req)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleCreateRule_AcceptsSourceObjectAndSenderEmails(t *testing.T) {
+func TestCreateRule_AcceptsSourceObjectAndSenderEmails(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := `{
 		"name":"HDFC Credit Card",
@@ -2682,7 +2682,7 @@ func TestHandleCreateRule_AcceptsSourceObjectAndSenderEmails(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules", strings.NewReader(body))
 	rr := httptest.NewRecorder()
 
-	h.HandleCreateRule(rr, req)
+	h.CreateRule(rr, req)
 
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2700,12 +2700,12 @@ func TestHandleCreateRule_AcceptsSourceObjectAndSenderEmails(t *testing.T) {
 	}
 }
 
-func TestHandleCreateRule_DuplicateNameReturns409(t *testing.T) {
+func TestCreateRule_DuplicateNameReturns409(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{ruleErr: store.ErrRuleNameConflict}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules", strings.NewReader(validRuleBody))
 	rr := httptest.NewRecorder()
 
-	h.HandleCreateRule(rr, req)
+	h.CreateRule(rr, req)
 
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2717,7 +2717,7 @@ func TestHandleCreateRule_DuplicateNameReturns409(t *testing.T) {
 	}
 }
 
-func TestHandleCreateRule_ClearsActiveReaderCheckpoint(t *testing.T) {
+func TestCreateRule_ClearsActiveReaderCheckpoint(t *testing.T) {
 	ms := &mockStore{
 		activeReader: "gmail",
 		appConfig:    map[string]string{"reader.gmail.last_scan_at": "2026-04-27T00:00:00Z"},
@@ -2730,7 +2730,7 @@ func TestHandleCreateRule_ClearsActiveReaderCheckpoint(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules", strings.NewReader(validRuleBody))
 	rr := httptest.NewRecorder()
 
-	h.HandleCreateRule(rr, req)
+	h.CreateRule(rr, req)
 
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
@@ -2743,7 +2743,7 @@ func TestHandleCreateRule_ClearsActiveReaderCheckpoint(t *testing.T) {
 	}
 }
 
-func TestHandleCreateRule_RestartsRunningDaemonAfterCheckpointClear(t *testing.T) {
+func TestCreateRule_RestartsRunningDaemonAfterCheckpointClear(t *testing.T) {
 	ms := &mockStore{
 		activeReader: "gmail",
 		appConfig:    map[string]string{"reader.gmail.last_scan_at": "2026-04-27T00:00:00Z"},
@@ -2756,7 +2756,7 @@ func TestHandleCreateRule_RestartsRunningDaemonAfterCheckpointClear(t *testing.T
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules", strings.NewReader(validRuleBody))
 	rr := httptest.NewRecorder()
 
-	h.HandleCreateRule(rr, req)
+	h.CreateRule(rr, req)
 
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
@@ -2766,7 +2766,7 @@ func TestHandleCreateRule_RestartsRunningDaemonAfterCheckpointClear(t *testing.T
 	}
 }
 
-func TestHandleCreateRule_MissingAmountRegex_Returns422(t *testing.T) {
+func TestCreateRule_MissingAmountRegex_Returns422(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := `{
 		"name":"test",
@@ -2776,13 +2776,13 @@ func TestHandleCreateRule_MissingAmountRegex_Returns422(t *testing.T) {
 	}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules", strings.NewReader(body))
 	rr := httptest.NewRecorder()
-	h.HandleCreateRule(rr, req)
+	h.CreateRule(rr, req)
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", rr.Code)
 	}
 }
 
-func TestHandleCreateRule_InvalidAmountRegex_Returns422(t *testing.T) {
+func TestCreateRule_InvalidAmountRegex_Returns422(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := `{
 		"name":"test",
@@ -2793,13 +2793,13 @@ func TestHandleCreateRule_InvalidAmountRegex_Returns422(t *testing.T) {
 	}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules", strings.NewReader(body))
 	rr := httptest.NewRecorder()
-	h.HandleCreateRule(rr, req)
+	h.CreateRule(rr, req)
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d", rr.Code)
 	}
 }
 
-func TestHandleUpdateRule_AnyRule_FullUpdate(t *testing.T) {
+func TestUpdateRule_AnyRule_FullUpdate(t *testing.T) {
 	ms := &mockStore{ruleResult: &store.RuleRow{ID: "1", Predefined: true}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	body := `{
@@ -2812,13 +2812,13 @@ func TestHandleUpdateRule_AnyRule_FullUpdate(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/rules/1", strings.NewReader(body))
 	req.SetPathValue("id", "1")
 	rr := httptest.NewRecorder()
-	h.HandleUpdateRule(rr, req)
+	h.UpdateRule(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleUpdateRule_DuplicateNameReturns409(t *testing.T) {
+func TestUpdateRule_DuplicateNameReturns409(t *testing.T) {
 	ms := &mockStore{ruleErr: store.ErrRuleNameConflict}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	body := `{
@@ -2832,7 +2832,7 @@ func TestHandleUpdateRule_DuplicateNameReturns409(t *testing.T) {
 	req.SetPathValue("id", "1")
 	rr := httptest.NewRecorder()
 
-	h.HandleUpdateRule(rr, req)
+	h.UpdateRule(rr, req)
 
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2844,31 +2844,31 @@ func TestHandleUpdateRule_DuplicateNameReturns409(t *testing.T) {
 	}
 }
 
-func TestHandleDeleteRule_PredefinedRule_Returns403(t *testing.T) {
+func TestDeleteRule_PredefinedRule_Returns403(t *testing.T) {
 	ms := &mockStore{ruleResult: &store.RuleRow{ID: "1", Predefined: true}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/rules/1", nil)
 	req.SetPathValue("id", "1")
 	rr := httptest.NewRecorder()
-	h.HandleDeleteRule(rr, req)
+	h.DeleteRule(rr, req)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rr.Code)
 	}
 }
 
-func TestHandleDeleteRule_UserRule_Returns204(t *testing.T) {
+func TestDeleteRule_UserRule_Returns204(t *testing.T) {
 	ms := &mockStore{ruleResult: &store.RuleRow{ID: "1", Predefined: false}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/rules/1", nil)
 	req.SetPathValue("id", "1")
 	rr := httptest.NewRecorder()
-	h.HandleDeleteRule(rr, req)
+	h.DeleteRule(rr, req)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("expected 204, got %d", rr.Code)
 	}
 }
 
-func TestHandleExportRules_OnlyNonPredefinedRules(t *testing.T) {
+func TestExportRules_OnlyNonPredefinedRules(t *testing.T) {
 	ms := &mockStore{rules: []store.RuleRow{
 		{ID: "1", Name: "predefined", Predefined: true, AmountRegex: `\d+`, MerchantRegex: `.+`},
 		{ID: "2", Name: "usr", Predefined: false, AmountRegex: `\d+`, MerchantRegex: `.+`},
@@ -2876,7 +2876,7 @@ func TestHandleExportRules_OnlyNonPredefinedRules(t *testing.T) {
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/rules/export", nil)
 	rr := httptest.NewRecorder()
-	h.HandleExportRules(rr, req)
+	h.ExportRules(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
@@ -2894,7 +2894,7 @@ func TestHandleExportRules_OnlyNonPredefinedRules(t *testing.T) {
 	}
 }
 
-func TestHandleExportRules_UsesVersionedDocument(t *testing.T) {
+func TestExportRules_UsesVersionedDocument(t *testing.T) {
 	ms := &mockStore{rules: []store.RuleRow{
 		{ID: "1", Name: "predefined", Predefined: true, AmountRegex: `\d+`, MerchantRegex: `.+`},
 		{
@@ -2913,7 +2913,7 @@ func TestHandleExportRules_UsesVersionedDocument(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/rules/export", nil)
 	rr := httptest.NewRecorder()
 
-	h.HandleExportRules(rr, req)
+	h.ExportRules(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
@@ -2941,7 +2941,7 @@ func TestHandleExportRules_UsesVersionedDocument(t *testing.T) {
 	}
 }
 
-func TestHandleImportRules_AcceptsVersionedDocument(t *testing.T) {
+func TestImportRules_AcceptsVersionedDocument(t *testing.T) {
 	ms := &mockStore{}
 	h := newTestHandlers(t, ms, &mockDaemon{})
 	body := `{
@@ -2959,7 +2959,7 @@ func TestHandleImportRules_AcceptsVersionedDocument(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules/import", strings.NewReader(body))
 	rr := httptest.NewRecorder()
 
-	h.HandleImportRules(rr, req)
+	h.ImportRules(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -2976,12 +2976,12 @@ func TestHandleImportRules_AcceptsVersionedDocument(t *testing.T) {
 	}
 }
 
-func TestHandleImportRules_InvalidRegex_Returns422(t *testing.T) {
+func TestImportRules_InvalidRegex_Returns422(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := `[{"name":"bad","amountRegex":"[invalid","merchantInfoRegex":".+"}]`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/rules/import", strings.NewReader(body))
 	rr := httptest.NewRecorder()
-	h.HandleImportRules(rr, req)
+	h.ImportRules(rr, req)
 	if rr.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -2989,11 +2989,11 @@ func TestHandleImportRules_InvalidRegex_Returns422(t *testing.T) {
 
 // --- thunderbird discovery + guide ---
 
-func TestHandleDiscoverProfiles_Returns200WithProfilesKey(t *testing.T) {
+func TestDiscoverProfiles_Returns200WithProfilesKey(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/thunderbird/discover/profiles", nil)
 	rr := httptest.NewRecorder()
-	h.HandleDiscoverProfiles(rr, req)
+	h.DiscoverProfiles(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -3005,18 +3005,18 @@ func TestHandleDiscoverProfiles_Returns200WithProfilesKey(t *testing.T) {
 	}
 }
 
-func TestHandleDiscoverMailboxes_MissingParam_Returns400(t *testing.T) {
+func TestDiscoverMailboxes_MissingParam_Returns400(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/thunderbird/discover/mailboxes", nil)
 	rr := httptest.NewRecorder()
-	h.HandleDiscoverMailboxes(rr, req)
+	h.DiscoverMailboxes(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
 }
 
-func TestHandleDiscoverMailboxes_NonexistentProfile_Returns404(t *testing.T) {
+func TestDiscoverMailboxes_NonexistentProfile_Returns404(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(
 		context.Background(), http.MethodGet,
@@ -3024,14 +3024,14 @@ func TestHandleDiscoverMailboxes_NonexistentProfile_Returns404(t *testing.T) {
 		nil,
 	)
 	rr := httptest.NewRecorder()
-	h.HandleDiscoverMailboxes(rr, req)
+	h.DiscoverMailboxes(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
 	}
 }
 
-func TestHandleGetReaderGuide_NoGuide_Returns404(t *testing.T) {
+func TestGetReaderGuide_NoGuide_Returns404(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	registry := plugins.NewRegistry()
 	if err := registry.RegisterReader(&testReaderPlugin{name: "noguide", authType: plugins.AuthTypeConfig}); err != nil {
@@ -3043,14 +3043,14 @@ func TestHandleGetReaderGuide_NoGuide_Returns404(t *testing.T) {
 	req.SetPathValue("name", "noguide")
 	rr := httptest.NewRecorder()
 
-	h.HandleGetReaderGuide(rr, req)
+	h.GetReaderGuide(rr, req)
 
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleGetReaderGuide_ReturnsMetadataGuide(t *testing.T) {
+func TestGetReaderGuide_ReturnsMetadataGuide(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	registry := plugins.NewRegistry()
 	guide := json.RawMessage(`{"sections":[{"title":"Setup","steps":[{"text":"Do the setup"}]}]}`)
@@ -3063,7 +3063,7 @@ func TestHandleGetReaderGuide_ReturnsMetadataGuide(t *testing.T) {
 	req.SetPathValue("name", "guided")
 	rr := httptest.NewRecorder()
 
-	h.HandleGetReaderGuide(rr, req)
+	h.GetReaderGuide(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
@@ -3075,7 +3075,7 @@ func TestHandleGetReaderGuide_ReturnsMetadataGuide(t *testing.T) {
 
 // --- rescan ---
 
-func TestHandleRescan_DaemonRunning_Returns202Rescanning(t *testing.T) {
+func TestRescan_DaemonRunning_Returns202Rescanning(t *testing.T) {
 	called := false
 	ms := &mockStore{}
 	dm := &mockDaemon{status: DaemonStatus{Running: true}}
@@ -3085,7 +3085,7 @@ func TestHandleRescan_DaemonRunning_Returns202Rescanning(t *testing.T) {
 	body := `{"reader":"gmail"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/daemon/rescan", strings.NewReader(body))
 	rr := httptest.NewRecorder()
-	h.HandleRescan(rr, req)
+	h.Rescan(rr, req)
 
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("expected 202, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -3100,7 +3100,7 @@ func TestHandleRescan_DaemonRunning_Returns202Rescanning(t *testing.T) {
 	}
 }
 
-func TestHandleRescan_DaemonNotRunning_Returns202Rescanning(t *testing.T) {
+func TestRescan_DaemonNotRunning_Returns202Rescanning(t *testing.T) {
 	called := false
 	ms := &mockStore{}
 	dm := &mockDaemon{status: DaemonStatus{Running: false}}
@@ -3110,7 +3110,7 @@ func TestHandleRescan_DaemonNotRunning_Returns202Rescanning(t *testing.T) {
 	body := `{"reader":"gmail"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/daemon/rescan", strings.NewReader(body))
 	rr := httptest.NewRecorder()
-	h.HandleRescan(rr, req)
+	h.Rescan(rr, req)
 
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("expected 202, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -3125,72 +3125,72 @@ func TestHandleRescan_DaemonNotRunning_Returns202Rescanning(t *testing.T) {
 	}
 }
 
-// --- HandleAuthExchange ---
+// --- AuthExchange ---
 
-func TestHandleAuthExchange_MissingURL_Returns400(t *testing.T) {
+func TestAuthExchange_MissingURL_Returns400(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/gmail/auth/exchange", strings.NewReader(`{}`))
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleAuthExchange(rr, req)
+	h.AuthExchange(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for missing url, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleAuthExchange_MalformedURL_Returns400(t *testing.T) {
+func TestAuthExchange_MalformedURL_Returns400(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/gmail/auth/exchange", strings.NewReader(`{"url":":::not-a-url"}`))
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleAuthExchange(rr, req)
+	h.AuthExchange(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for malformed url, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleAuthExchange_MissingCode_Returns400(t *testing.T) {
+func TestAuthExchange_MissingCode_Returns400(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	body := `{"url":"http://localhost:8080/api/auth/callback?state=somestate"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/gmail/auth/exchange", strings.NewReader(body))
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleAuthExchange(rr, req)
+	h.AuthExchange(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for missing code, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleAuthExchange_MissingState_Returns400(t *testing.T) {
+func TestAuthExchange_MissingState_Returns400(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	body := `{"url":"http://localhost:8080/api/auth/callback?code=4%2F0Acode"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/gmail/auth/exchange", strings.NewReader(body))
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleAuthExchange(rr, req)
+	h.AuthExchange(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for missing state, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleAuthExchange_UnknownState_Returns400(t *testing.T) {
+func TestAuthExchange_UnknownState_Returns400(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 	body := `{"url":"http://localhost:8080/api/auth/callback?code=4%2F0Acode&state=doesnotexist"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/gmail/auth/exchange", strings.NewReader(body))
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleAuthExchange(rr, req)
+	h.AuthExchange(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for unknown state, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleAuthExchange_ExpiredState_Returns400(t *testing.T) {
+func TestAuthExchange_ExpiredState_Returns400(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	expiredState := "reader:gmail:expiredtoken"
@@ -3205,14 +3205,14 @@ func TestHandleAuthExchange_ExpiredState_Returns400(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/gmail/auth/exchange", strings.NewReader(body))
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleAuthExchange(rr, req)
+	h.AuthExchange(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for expired state, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 
-func TestHandleAuthExchange_RestartsRunningDaemonAfterTokenSaved(t *testing.T) {
+func TestAuthExchange_RestartsRunningDaemonAfterTokenSaved(t *testing.T) {
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Fatalf("token endpoint method = %s, want POST", r.Method)
@@ -3249,7 +3249,7 @@ func TestHandleAuthExchange_RestartsRunningDaemonAfterTokenSaved(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/readers/gmail/auth/exchange", strings.NewReader(body))
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
-	h.HandleAuthExchange(rr, req)
+	h.AuthExchange(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
@@ -3262,7 +3262,7 @@ func TestHandleAuthExchange_RestartsRunningDaemonAfterTokenSaved(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_BucketParam(t *testing.T) {
+func TestListTransactions_BucketParam(t *testing.T) {
 	now := time.Now()
 	st := &mockStore{
 		transactions: []store.Transaction{
@@ -3274,7 +3274,7 @@ func TestHandleListTransactions_BucketParam(t *testing.T) {
 		listResult: store.TransactionListResult{Total: 1},
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
-	rr := get(h.HandleListTransactions, "/api/transactions?bucket=wants")
+	rr := get(h.ListTransactions, "/api/transactions?bucket=wants")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
@@ -3286,11 +3286,11 @@ func TestHandleListTransactions_BucketParam(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_WeekdayHourTimezoneParams(t *testing.T) {
+func TestListTransactions_WeekdayHourTimezoneParams(t *testing.T) {
 	st := &mockStore{transactions: []store.Transaction{}, listResult: store.TransactionListResult{Total: 0}}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
-	rr := get(h.HandleListTransactions, "/api/transactions?weekday=5&hour_from=9&hour_to=9&tz=Asia/Kolkata")
+	rr := get(h.ListTransactions, "/api/transactions?weekday=5&hour_from=9&hour_to=9&tz=Asia/Kolkata")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
@@ -3309,12 +3309,12 @@ func TestHandleListTransactions_WeekdayHourTimezoneParams(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_WeekdayHourTimezoneAndDateParams(t *testing.T) {
+func TestListTransactions_WeekdayHourTimezoneAndDateParams(t *testing.T) {
 	st := &mockStore{transactions: []store.Transaction{}, listResult: store.TransactionListResult{Total: 0}}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
 	rr := get(
-		h.HandleListTransactions,
+		h.ListTransactions,
 		"/api/transactions?weekday=0&hour_from=23&hour_to=23&tz=Asia/Calcutta&date_from=2026-04-01T00:00:00.000Z&date_to=2026-04-30T23:59:59.000Z",
 	)
 
@@ -3341,12 +3341,12 @@ func TestHandleListTransactions_WeekdayHourTimezoneAndDateParams(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_ExcludeParams(t *testing.T) {
+func TestListTransactions_ExcludeParams(t *testing.T) {
 	st := &mockStore{transactions: []store.Transaction{}, listResult: store.TransactionListResult{Total: 0}}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
 	rr := get(
-		h.HandleListTransactions,
+		h.ListTransactions,
 		"/api/transactions?exclude_categories=Shopping,Food%20%26%20Dining&exclude_labels=Top,Recurring&exclude_buckets=Needs,Wants&exclude_sources=HDFC,Amex",
 	)
 
@@ -3367,12 +3367,12 @@ func TestHandleListTransactions_ExcludeParams(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_StructuredSourceParams(t *testing.T) {
+func TestListTransactions_StructuredSourceParams(t *testing.T) {
 	st := &mockStore{transactions: []store.Transaction{}, listResult: store.TransactionListResult{Total: 0}}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
 	rr := get(
-		h.HandleListTransactions,
+		h.ListTransactions,
 		"/api/transactions?source_type=Credit%20Card&bank=HDFC&exclude_source_types=UPI,NetBanking&exclude_banks=ICICI,SBI",
 	)
 
@@ -3393,12 +3393,12 @@ func TestHandleListTransactions_StructuredSourceParams(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_MissingTaxonomyParams(t *testing.T) {
+func TestListTransactions_MissingTaxonomyParams(t *testing.T) {
 	st := &mockStore{transactions: []store.Transaction{}, listResult: store.TransactionListResult{Total: 0}}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
 	rr := get(
-		h.HandleListTransactions,
+		h.ListTransactions,
 		"/api/transactions?category_missing=1&bucket_missing=1&label_missing=1",
 	)
 
@@ -3416,7 +3416,7 @@ func TestHandleListTransactions_MissingTaxonomyParams(t *testing.T) {
 	}
 }
 
-func TestHandleListTransactions_InvalidTimezoneFallsBackToAppTimezone(t *testing.T) {
+func TestListTransactions_InvalidTimezoneFallsBackToAppTimezone(t *testing.T) {
 	st := &mockStore{
 		transactions: []store.Transaction{},
 		listResult:   store.TransactionListResult{Total: 0},
@@ -3424,7 +3424,7 @@ func TestHandleListTransactions_InvalidTimezoneFallsBackToAppTimezone(t *testing
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
-	rr := get(h.HandleListTransactions, "/api/transactions?weekday=5&hour_from=9&hour_to=9&tz=Not/AZone")
+	rr := get(h.ListTransactions, "/api/transactions?weekday=5&hour_from=9&hour_to=9&tz=Not/AZone")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
@@ -3434,7 +3434,7 @@ func TestHandleListTransactions_InvalidTimezoneFallsBackToAppTimezone(t *testing
 	}
 }
 
-func TestHandleListTransactions_MissingTimezoneFallsBackToAppTimezone(t *testing.T) {
+func TestListTransactions_MissingTimezoneFallsBackToAppTimezone(t *testing.T) {
 	st := &mockStore{
 		transactions: []store.Transaction{},
 		listResult:   store.TransactionListResult{Total: 0},
@@ -3442,7 +3442,7 @@ func TestHandleListTransactions_MissingTimezoneFallsBackToAppTimezone(t *testing
 	}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
-	rr := get(h.HandleListTransactions, "/api/transactions?weekday=5&hour_from=9&hour_to=9")
+	rr := get(h.ListTransactions, "/api/transactions?weekday=5&hour_from=9&hour_to=9")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
@@ -3452,11 +3452,11 @@ func TestHandleListTransactions_MissingTimezoneFallsBackToAppTimezone(t *testing
 	}
 }
 
-func TestHandleGetTimezoneDefaultsToEmptyWhenUnset(t *testing.T) {
+func TestGetTimezoneDefaultsToEmptyWhenUnset(t *testing.T) {
 	st := &mockStore{}
 	h := newTestHandlers(t, st, &mockDaemon{})
 
-	rr := get(h.HandleGetTimezone, "/api/config/timezone")
+	rr := get(h.GetTimezone, "/api/config/timezone")
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
@@ -3473,7 +3473,7 @@ func TestHandleGetTimezoneDefaultsToEmptyWhenUnset(t *testing.T) {
 
 // --- banks ---
 
-func TestHandleListBanks(t *testing.T) {
+func TestListBanks(t *testing.T) {
 	banksJSON := []byte(`[{"fragment":"hdfc","color":"#E31837","name":"HDFC Bank"}]`)
 
 	tests := []struct {
@@ -3501,7 +3501,7 @@ func TestHandleListBanks(t *testing.T) {
 			h := newTestHandlers(t, &mockStore{}, &mockDaemon{}, tc.banksData)
 			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/banks", nil)
 			w := httptest.NewRecorder()
-			h.HandleListBanks(w, req)
+			h.ListBanks(w, req)
 			if w.Code != tc.wantStatus {
 				t.Errorf("got status %d, want %d", w.Code, tc.wantStatus)
 			}
@@ -3532,12 +3532,12 @@ func (m *mockStore) GetSyncStatus(_ context.Context) (store.SyncStatus, error) {
 }
 func (m *mockStore) SetSyncStatus(_ context.Context, _ store.SyncStatus) error { return nil }
 
-func TestHandleGetSyncStatus_NoStore(t *testing.T) {
+func TestGetSyncStatus_NoStore(t *testing.T) {
 	h := newTestHandlers(t, nil, &mockDaemon{})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/sync/status", nil)
 	rr := httptest.NewRecorder()
-	h.HandleGetSyncStatus(rr, req)
+	h.GetSyncStatus(rr, req)
 
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", rr.Code)
@@ -3549,13 +3549,13 @@ func TestHandleGetSyncStatus_NoStore(t *testing.T) {
 	}
 }
 
-func TestHandleCategorizeMerchant_OK(t *testing.T) {
+func TestCategorizeMerchant_OK(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := `{"merchant":"Netflix","category":"Entertainment","bucket":"Wants"}`
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/merchants/categorize", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	h.HandleCategorizeMerchant(w, r)
+	h.CategorizeMerchant(w, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -3568,36 +3568,36 @@ func TestHandleCategorizeMerchant_OK(t *testing.T) {
 	}
 }
 
-func TestHandleCategorizeMerchant_EmptyMerchant(t *testing.T) {
+func TestCategorizeMerchant_EmptyMerchant(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	body := `{"merchant":"","category":"Entertainment","bucket":"Wants"}`
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/merchants/categorize", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	h.HandleCategorizeMerchant(w, r)
+	h.CategorizeMerchant(w, r)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", w.Code)
 	}
 }
 
-func TestHandleCategorizeMerchant_InvalidJSON(t *testing.T) {
+func TestCategorizeMerchant_InvalidJSON(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/merchants/categorize", strings.NewReader("not-json"))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	h.HandleCategorizeMerchant(w, r)
+	h.CategorizeMerchant(w, r)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", w.Code)
 	}
 }
 
-func TestHandleCategorizeMerchant_StoreError(t *testing.T) {
+func TestCategorizeMerchant_StoreError(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{updateErr: errors.New("db down")}, &mockDaemon{})
 	body := `{"merchant":"Netflix","category":"Entertainment","bucket":"Wants"}`
 	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/merchants/categorize", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	h.HandleCategorizeMerchant(w, r)
+	h.CategorizeMerchant(w, r)
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", w.Code)
 	}

--- a/backend/internal/api/handlers_transactions.go
+++ b/backend/internal/api/handlers_transactions.go
@@ -16,7 +16,7 @@ import (
 
 // --- transactions ---
 
-// HandleListTransactions handles GET /api/transactions.
+// ListTransactions handles GET /api/transactions.
 // @Summary List transactions
 // @Tags Transactions
 // @Produce json
@@ -44,12 +44,12 @@ import (
 // @Param hour_to query int false "Maximum hour filter (0-23)"
 // @Param tz query string false "IANA timezone used for weekday/hour filters"
 // @Param sort_dir query string false "Sort direction" Enums(asc,desc)
-// @Success 200 {object} DocTransactionsListResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} TransactionsListResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions [get]
-func (h *Handlers) HandleListTransactions(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) ListTransactions(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -135,7 +135,7 @@ func (h *Handlers) HandleListTransactions(w http.ResponseWriter, r *http.Request
 		"transactions":  txns,
 		"total":         result.Total,
 		"total_amount":  result.TotalAmount,
-		"base_currency": h.getBaseCurrency(r.Context()),
+		"base_currency": h.currentBaseCurrency(r.Context()),
 		"page":          f.Page,
 		"page_size":     f.PageSize,
 	})
@@ -178,18 +178,18 @@ func containsControlChars(value string) bool {
 	return false
 }
 
-// HandleGetTransaction handles GET /api/transactions/{id}.
+// GetTransaction handles GET /api/transactions/{id}.
 // @Summary Get a transaction
 // @Tags Transactions
 // @Produce json
 // @Param id path string true "Transaction ID"
-// @Success 200 {object} DocTransactionResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 404 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} TransactionResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id} [get]
-func (h *Handlers) HandleGetTransaction(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetTransaction(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -247,7 +247,7 @@ func (h *Handlers) validateBucket(w http.ResponseWriter, r *http.Request, name s
 	return false
 }
 
-// HandleUpdateTransaction handles PUT /api/transactions/{id}.
+// UpdateTransaction handles PUT /api/transactions/{id}.
 // Body: {"description": "...", "category": "...", "bucket": "..."}
 // All fields are optional; only non-nil fields are written.
 // @Summary Update a transaction
@@ -255,14 +255,14 @@ func (h *Handlers) validateBucket(w http.ResponseWriter, r *http.Request, name s
 // @Accept json
 // @Produce json
 // @Param id path string true "Transaction ID"
-// @Param request body DocTransactionUpdateRequest true "Transaction update payload"
-// @Success 200 {object} DocTransactionResponse
-// @Failure 404 {object} DocErrorResponse
-// @Failure 422 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body TransactionUpdateRequest true "Transaction update payload"
+// @Success 200 {object} TransactionResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 422 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id} [put]
-func (h *Handlers) HandleUpdateTransaction(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) UpdateTransaction(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -310,21 +310,21 @@ func (h *Handlers) HandleUpdateTransaction(w http.ResponseWriter, r *http.Reques
 
 // --- muted transactions ---
 
-// HandleMuteTransaction handles PUT /api/transactions/{id}/mute.
+// MuteTransaction handles PUT /api/transactions/{id}/mute.
 // Body: {"muted": true|false}
 // @Summary Mute or unmute a transaction
 // @Tags Transactions
 // @Accept json
 // @Produce json
 // @Param id path string true "Transaction ID"
-// @Param request body DocMuteTransactionRequest true "Mute payload"
-// @Success 200 {object} DocMuteTransactionResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 404 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body MuteTransactionRequest true "Mute payload"
+// @Success 200 {object} MuteTransactionResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id}/mute [put]
-func (h *Handlers) HandleMuteTransaction(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) MuteTransaction(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -350,7 +350,7 @@ func (h *Handlers) HandleMuteTransaction(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]any{"muted": body.Muted, "reason": body.Reason})
 }
 
-// HandleUpdateMuteReason handles PUT /api/transactions/{id}/mute-reason.
+// UpdateMuteReason handles PUT /api/transactions/{id}/mute-reason.
 // Body: {"reason": "optional text"}
 //
 // @Summary Update a transaction mute reason
@@ -358,16 +358,16 @@ func (h *Handlers) HandleMuteTransaction(w http.ResponseWriter, r *http.Request)
 // @Accept json
 // @Produce json
 // @Param id path string true "Transaction ID"
-// @Param request body DocUpdateMuteReasonRequest true "Mute reason payload"
-// @Success 200 {object} DocMuteReasonResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 404 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Param request body UpdateMuteReasonRequest true "Mute reason payload"
+// @Success 200 {object} MuteReasonResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id}/mute-reason [put]
 //
-//nolint:dupl // structurally similar to HandleUpdateMerchantReason but calls a different store method
-func (h *Handlers) HandleUpdateMuteReason(w http.ResponseWriter, r *http.Request) {
+//nolint:dupl // structurally similar to UpdateMerchantReason but calls a different store method
+func (h *Handlers) UpdateMuteReason(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -392,8 +392,8 @@ func (h *Handlers) HandleUpdateMuteReason(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, map[string]string{"reason": body.Reason})
 }
 
-// HandleListMutedMerchants handles GET /api/muted-merchants.
-func (h *Handlers) HandleListMutedMerchants(w http.ResponseWriter, r *http.Request) {
+// ListMutedMerchants handles GET /api/muted-merchants.
+func (h *Handlers) ListMutedMerchants(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -407,9 +407,9 @@ func (h *Handlers) HandleListMutedMerchants(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, merchants)
 }
 
-// HandleMuteByMerchant handles POST /api/muted-merchants.
+// MuteByMerchant handles POST /api/muted-merchants.
 // Body: {"pattern": "MERCHANT NAME", "reason": "optional"}
-func (h *Handlers) HandleMuteByMerchant(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) MuteByMerchant(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -430,11 +430,11 @@ func (h *Handlers) HandleMuteByMerchant(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusCreated, map[string]string{"pattern": body.Pattern})
 }
 
-// HandleUpdateMerchantReason handles PUT /api/muted-merchants/{id}/reason.
+// UpdateMerchantReason handles PUT /api/muted-merchants/{id}/reason.
 // Body: {"reason": "optional text"}
 //
-//nolint:dupl // structurally similar to HandleUpdateMuteReason but calls a different store method
-func (h *Handlers) HandleUpdateMerchantReason(w http.ResponseWriter, r *http.Request) {
+//nolint:dupl // structurally similar to UpdateMuteReason but calls a different store method
+func (h *Handlers) UpdateMerchantReason(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -459,10 +459,10 @@ func (h *Handlers) HandleUpdateMerchantReason(w http.ResponseWriter, r *http.Req
 	writeJSON(w, http.StatusOK, map[string]string{"reason": body.Reason})
 }
 
-// HandleDeleteMutedMerchant handles DELETE /api/muted-merchants/{id}.
+// DeleteMutedMerchant handles DELETE /api/muted-merchants/{id}.
 // Optional query param: ?unmute=true — atomically deletes the rule and
 // sets muted=false on all existing transactions that matched the pattern.
-func (h *Handlers) HandleDeleteMutedMerchant(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) DeleteMutedMerchant(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -489,10 +489,10 @@ func (h *Handlers) HandleDeleteMutedMerchant(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// HandleCategorizeMerchant handles POST /api/merchants/categorize.
+// CategorizeMerchant handles POST /api/merchants/categorize.
 // Body: {"merchant": "Name", "category": "Cat", "bucket": "Bucket"}
 // Response: {"updated": N}
-func (h *Handlers) HandleCategorizeMerchant(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) CategorizeMerchant(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -519,7 +519,7 @@ func (h *Handlers) HandleCategorizeMerchant(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, map[string]int{"updated": n})
 }
 
-// HandleSearchTransactions handles GET /api/transactions/search?q=...
+// SearchTransactions handles GET /api/transactions/search?q=...
 // @Summary Search transactions
 // @Tags Transactions
 // @Produce json
@@ -527,12 +527,12 @@ func (h *Handlers) HandleCategorizeMerchant(w http.ResponseWriter, r *http.Reque
 // @Param page query int false "1-based page number" default(1)
 // @Param page_size query int false "Page size" default(20)
 // @Param show_muted query int false "Include muted transactions when set to 1" Enums(1)
-// @Success 200 {object} DocTransactionsSearchResponse
-// @Failure 400 {object} DocErrorResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} TransactionsSearchResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions/search [get]
-func (h *Handlers) HandleSearchTransactions(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) SearchTransactions(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return
@@ -565,24 +565,24 @@ func (h *Handlers) HandleSearchTransactions(w http.ResponseWriter, r *http.Reque
 		"transactions":  txns,
 		"total":         result.Total,
 		"total_amount":  result.TotalAmount,
-		"base_currency": h.getBaseCurrency(r.Context()),
+		"base_currency": h.currentBaseCurrency(r.Context()),
 		"page":          f.Page,
 		"page_size":     f.PageSize,
 		"query":         q,
 	})
 }
 
-// HandleGetFacets handles GET /api/transactions/facets.
+// GetFacets handles GET /api/transactions/facets.
 // Returns distinct values for source, category, currency, and label — used to
 // populate filter dropdowns in the UI.
 // @Summary Get transaction facets
 // @Tags Transactions
 // @Produce json
-// @Success 200 {object} DocFacetsResponse
-// @Failure 500 {object} DocErrorResponse
-// @Failure 503 {object} DocErrorResponse
+// @Success 200 {object} FacetsResponse
+// @Failure 500 {object} ErrorResponse
+// @Failure 503 {object} ErrorResponse
 // @Router /transactions/facets [get]
-func (h *Handlers) HandleGetFacets(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetFacets(w http.ResponseWriter, r *http.Request) {
 	if h.store == nil {
 		writeError(w, http.StatusServiceUnavailable, "database not connected")
 		return

--- a/backend/internal/api/http_helpers.go
+++ b/backend/internal/api/http_helpers.go
@@ -9,8 +9,8 @@ import (
 
 // --- helpers ---
 
-// getBaseCurrency returns the base currency from the DB, falling back to INR.
-func (h *Handlers) getBaseCurrency(ctx context.Context) string {
+// currentBaseCurrency returns the base currency from the DB, falling back to INR.
+func (h *Handlers) currentBaseCurrency(ctx context.Context) string {
 	if h.store != nil {
 		if val, err := h.store.GetAppConfig(ctx, "base_currency"); err == nil && val != "" {
 			return val

--- a/backend/internal/api/openapi_types.go
+++ b/backend/internal/api/openapi_types.go
@@ -2,23 +2,23 @@ package api
 
 import "time"
 
-// DocErrorResponse is the standard JSON error payload for OpenAPI generation.
-type DocErrorResponse struct {
+// ErrorResponse is the standard JSON error payload for OpenAPI generation.
+type ErrorResponse struct {
 	Error string `json:"error" example:"database not connected"`
 }
 
-// DocHealthResponse is the health check payload.
-type DocHealthResponse struct {
+// HealthResponse is the health check payload.
+type HealthResponse struct {
 	Status string `json:"status" example:"ok"`
 }
 
-// DocVersionResponse is the version payload.
-type DocVersionResponse struct {
+// VersionResponse is the version payload.
+type VersionResponse struct {
 	Version string `json:"version" example:"dev"`
 }
 
-// DocStatsResponse documents the stats payload embedded in status responses.
-type DocStatsResponse struct {
+// StatsResponse documents the stats payload embedded in status responses.
+type StatsResponse struct {
 	TotalCount         int                `json:"total_count"`
 	TotalBase          float64            `json:"total_base"`
 	BaseCurrency       string             `json:"base_currency" example:"INR"`
@@ -26,172 +26,172 @@ type DocStatsResponse struct {
 	TotalCategoryCount map[string]int     `json:"total_category_count"`
 }
 
-// DocStatusResponse documents the combined daemon and stats status payload.
-type DocStatusResponse struct {
-	Daemon DaemonStatus      `json:"daemon"`
-	Stats  *DocStatsResponse `json:"stats,omitempty"`
+// StatusResponse documents the combined daemon and stats status payload.
+type StatusResponse struct {
+	Daemon DaemonStatus   `json:"daemon"`
+	Stats  *StatsResponse `json:"stats,omitempty"`
 }
 
-// DocDaemonReaderRequest is the daemon start/rescan request body.
-type DocDaemonReaderRequest struct {
+// DaemonReaderRequest is the daemon start/rescan request body.
+type DaemonReaderRequest struct {
 	Reader string `json:"reader" example:"gmail"`
 }
 
-// DocStatusOnlyResponse is a simple status message payload.
-type DocStatusOnlyResponse struct {
+// StatusOnlyResponse is a simple status message payload.
+type StatusOnlyResponse struct {
 	Status string `json:"status" example:"ok"`
 }
 
-// DocActiveReaderResponse is the active reader config payload.
-type DocActiveReaderResponse struct {
+// ActiveReaderResponse is the active reader config payload.
+type ActiveReaderResponse struct {
 	Reader string `json:"reader" example:"gmail"`
 }
 
-// DocBaseCurrencyRequest is the base currency update payload.
-type DocBaseCurrencyRequest struct {
+// BaseCurrencyRequest is the base currency update payload.
+type BaseCurrencyRequest struct {
 	BaseCurrency string `json:"base_currency" example:"USD"`
 }
 
-// DocBaseCurrencyResponse is the base currency payload.
-type DocBaseCurrencyResponse struct {
+// BaseCurrencyResponse is the base currency payload.
+type BaseCurrencyResponse struct {
 	BaseCurrency string `json:"base_currency" example:"USD"`
 }
 
-// DocScanIntervalRequest is the scan interval update payload.
-type DocScanIntervalRequest struct {
+// ScanIntervalRequest is the scan interval update payload.
+type ScanIntervalRequest struct {
 	ScanInterval string `json:"scan_interval" example:"120"`
 }
 
-// DocScanIntervalResponse is the scan interval payload.
-type DocScanIntervalResponse struct {
+// ScanIntervalResponse is the scan interval payload.
+type ScanIntervalResponse struct {
 	ScanInterval string `json:"scan_interval" example:"120"`
 }
 
-// DocLookbackDaysRequest is the lookback days update payload.
-type DocLookbackDaysRequest struct {
+// LookbackDaysRequest is the lookback days update payload.
+type LookbackDaysRequest struct {
 	LookbackDays string `json:"lookback_days" example:"365"`
 }
 
-// DocLookbackDaysResponse is the lookback days payload.
-type DocLookbackDaysResponse struct {
+// LookbackDaysResponse is the lookback days payload.
+type LookbackDaysResponse struct {
 	LookbackDays string `json:"lookback_days" example:"365"`
 }
 
-// DocTimezoneRequest is the timezone update payload.
-type DocTimezoneRequest struct {
+// TimezoneRequest is the timezone update payload.
+type TimezoneRequest struct {
 	Timezone string `json:"timezone" example:"Asia/Kolkata"`
 }
 
-// DocTimezoneResponse is the timezone payload.
-type DocTimezoneResponse struct {
+// TimezoneResponse is the timezone payload.
+type TimezoneResponse struct {
 	Timezone string `json:"timezone" example:"Asia/Kolkata"`
 }
 
-// DocTimeFormatRequest is the time format update payload.
-type DocTimeFormatRequest struct {
+// TimeFormatRequest is the time format update payload.
+type TimeFormatRequest struct {
 	TimeFormat string `json:"time_format" example:"HH:mm"`
 }
 
-// DocTimeFormatResponse is the time format payload.
-type DocTimeFormatResponse struct {
+// TimeFormatResponse is the time format payload.
+type TimeFormatResponse struct {
 	TimeFormat string `json:"time_format" example:"HH:mm"`
 }
 
-// DocSetupStatusResponse is the first-run setup status payload.
-type DocSetupStatusResponse struct {
+// SetupStatusResponse is the first-run setup status payload.
+type SetupStatusResponse struct {
 	Required bool     `json:"required" example:"true"`
 	Missing  []string `json:"missing" example:"base_currency,timezone,time_format"`
 }
 
-// DocReaderCheckpointResponse is the reader checkpoint payload.
-type DocReaderCheckpointResponse struct {
+// ReaderCheckpointResponse is the reader checkpoint payload.
+type ReaderCheckpointResponse struct {
 	LastScanAt *string `json:"last_scan_at" example:"2026-04-14T09:00:00Z" extensions:"x-nullable"`
 }
 
-// DocSyncStatusResponse is the community sync status payload.
-type DocSyncStatusResponse struct {
+// SyncStatusResponse is the community sync status payload.
+type SyncStatusResponse struct {
 	LastSyncedAt   *time.Time `json:"last_synced_at,omitempty" extensions:"x-nullable"`
 	Error          *string    `json:"error,omitempty" extensions:"x-nullable"`
 	EntriesUpdated int        `json:"entries_updated"`
 }
 
-// DocLabelResponse documents a managed label.
-type DocLabelResponse struct {
+// LabelResponse documents a managed label.
+type LabelResponse struct {
 	Name      string    `json:"name" example:"food"`
 	Color     string    `json:"color" example:"#f59e0b"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// DocCreateLabelRequest is the label creation payload.
-type DocCreateLabelRequest struct {
+// CreateLabelRequest is the label creation payload.
+type CreateLabelRequest struct {
 	Name  string `json:"name" example:"food"`
 	Color string `json:"color" example:"#f59e0b"`
 }
 
-// DocUpdateLabelRequest is the label update payload.
-type DocUpdateLabelRequest struct {
+// UpdateLabelRequest is the label update payload.
+type UpdateLabelRequest struct {
 	Color string `json:"color" example:"#f59e0b"`
 }
 
-// DocLabelMutationResponse is the label create/update response payload.
-type DocLabelMutationResponse struct {
+// LabelMutationResponse is the label create/update response payload.
+type LabelMutationResponse struct {
 	Name  string `json:"name" example:"food"`
 	Color string `json:"color" example:"#f59e0b"`
 }
 
-// DocApplyLabelRequest is the label-by-merchant apply payload.
-type DocApplyLabelRequest struct {
+// ApplyLabelRequest is the label-by-merchant apply payload.
+type ApplyLabelRequest struct {
 	MerchantPattern string `json:"merchant_pattern" example:"swiggy"`
 }
 
-// DocAppliedCountResponse is the count payload for apply actions.
-type DocAppliedCountResponse struct {
+// AppliedCountResponse is the count payload for apply actions.
+type AppliedCountResponse struct {
 	Applied int64 `json:"applied"`
 }
 
-// DocLabelMappingsResponse documents label-to-merchant mappings.
-type DocLabelMappingsResponse map[string][]string
+// LabelMappingsResponse documents label-to-merchant mappings.
+type LabelMappingsResponse map[string][]string
 
-// DocCategoryResponse documents a managed category.
-type DocCategoryResponse struct {
+// CategoryResponse documents a managed category.
+type CategoryResponse struct {
 	Name        string `json:"name" example:"Food"`
 	Description string `json:"description,omitempty" example:"Restaurants and groceries"`
 	IsDefault   bool   `json:"is_default"`
 }
 
-// DocCreateCategoryRequest is the category creation payload.
-type DocCreateCategoryRequest struct {
+// CreateCategoryRequest is the category creation payload.
+type CreateCategoryRequest struct {
 	Name        string `json:"name" example:"Food"`
 	Description string `json:"description,omitempty" example:"Restaurants and groceries"`
 }
 
-// DocBucketResponse documents a managed bucket.
-type DocBucketResponse struct {
+// BucketResponse documents a managed bucket.
+type BucketResponse struct {
 	Name        string `json:"name" example:"Needs"`
 	Description string `json:"description,omitempty" example:"Essential spending"`
 	IsDefault   bool   `json:"is_default"`
 }
 
-// DocCreateBucketRequest is the bucket creation payload.
-type DocCreateBucketRequest struct {
+// CreateBucketRequest is the bucket creation payload.
+type CreateBucketRequest struct {
 	Name        string `json:"name" example:"Needs"`
 	Description string `json:"description,omitempty" example:"Essential spending"`
 }
 
-// DocNameResponse is a simple named resource payload.
-type DocNameResponse struct {
+// NameResponse is a simple named resource payload.
+type NameResponse struct {
 	Name string `json:"name" example:"Food"`
 }
 
-// DocBankColorResponse documents an embedded bank color mapping.
-type DocBankColorResponse struct {
+// BankColorResponse documents an embedded bank color mapping.
+type BankColorResponse struct {
 	Fragment string `json:"fragment" example:"hdfc"`
 	Color    string `json:"color" example:"#2563eb"`
 	Name     string `json:"name" example:"HDFC Bank"`
 }
 
-// DocTransactionResponse documents a transaction payload.
-type DocTransactionResponse struct {
+// TransactionResponse documents a transaction payload.
+type TransactionResponse struct {
 	ID               string    `json:"id" example:"tx_123"`
 	MessageID        string    `json:"message_id" example:"gmail-message-id"`
 	Amount           float64   `json:"amount" example:"249.50"`
@@ -213,29 +213,29 @@ type DocTransactionResponse struct {
 	UpdatedAt        time.Time `json:"updated_at"`
 }
 
-// DocTransactionsListResponse documents the paginated list payload.
-type DocTransactionsListResponse struct {
-	Transactions []DocTransactionResponse `json:"transactions"`
-	Total        int                      `json:"total"`
-	TotalAmount  float64                  `json:"total_amount"`
-	BaseCurrency string                   `json:"base_currency" example:"INR"`
-	Page         int                      `json:"page"`
-	PageSize     int                      `json:"page_size"`
+// TransactionsListResponse documents the paginated list payload.
+type TransactionsListResponse struct {
+	Transactions []TransactionResponse `json:"transactions"`
+	Total        int                   `json:"total"`
+	TotalAmount  float64               `json:"total_amount"`
+	BaseCurrency string                `json:"base_currency" example:"INR"`
+	Page         int                   `json:"page"`
+	PageSize     int                   `json:"page_size"`
 }
 
-// DocTransactionsSearchResponse documents the paginated search payload.
-type DocTransactionsSearchResponse struct {
-	Transactions []DocTransactionResponse `json:"transactions"`
-	Total        int                      `json:"total"`
-	TotalAmount  float64                  `json:"total_amount"`
-	BaseCurrency string                   `json:"base_currency" example:"INR"`
-	Page         int                      `json:"page"`
-	PageSize     int                      `json:"page_size"`
-	Query        string                   `json:"query" example:"coffee"`
+// TransactionsSearchResponse documents the paginated search payload.
+type TransactionsSearchResponse struct {
+	Transactions []TransactionResponse `json:"transactions"`
+	Total        int                   `json:"total"`
+	TotalAmount  float64               `json:"total_amount"`
+	BaseCurrency string                `json:"base_currency" example:"INR"`
+	Page         int                   `json:"page"`
+	PageSize     int                   `json:"page_size"`
+	Query        string                `json:"query" example:"coffee"`
 }
 
-// DocExtractionDiagnosticResponse documents an extraction diagnostic payload.
-type DocExtractionDiagnosticResponse struct {
+// ExtractionDiagnosticResponse documents an extraction diagnostic payload.
+type ExtractionDiagnosticResponse struct {
 	ID             string     `json:"id" example:"11111111-1111-1111-1111-111111111111"`
 	Status         string     `json:"status" example:"open"`
 	Reader         string     `json:"reader" example:"gmail"`
@@ -258,13 +258,13 @@ type DocExtractionDiagnosticResponse struct {
 	ResolvedAt     *time.Time `json:"resolved_at,omitempty"`
 }
 
-// DocExtractionDiagnosticStatusRequest is the diagnostic status update payload.
-type DocExtractionDiagnosticStatusRequest struct {
+// ExtractionDiagnosticStatusRequest is the diagnostic status update payload.
+type ExtractionDiagnosticStatusRequest struct {
 	Status string `json:"status" example:"resolved"`
 }
 
-// DocFacetsResponse documents the distinct transaction filter values.
-type DocFacetsResponse struct {
+// FacetsResponse documents the distinct transaction filter values.
+type FacetsResponse struct {
 	Sources    []string `json:"sources"`
 	Categories []string `json:"categories"`
 	Currencies []string `json:"currencies"`
@@ -273,36 +273,36 @@ type DocFacetsResponse struct {
 	Buckets    []string `json:"buckets"`
 }
 
-// DocTransactionUpdateRequest is the transaction patch payload.
-type DocTransactionUpdateRequest struct {
+// TransactionUpdateRequest is the transaction patch payload.
+type TransactionUpdateRequest struct {
 	Description *string `json:"description,omitempty" example:"Dinner order"`
 	Category    *string `json:"category,omitempty" example:"Food"`
 	Bucket      *string `json:"bucket,omitempty" example:"Needs"`
 }
 
-// DocTransactionLabelsRequest is the transaction labels mutation payload.
-type DocTransactionLabelsRequest struct {
+// TransactionLabelsRequest is the transaction labels mutation payload.
+type TransactionLabelsRequest struct {
 	Labels []string `json:"labels"`
 }
 
-// DocMuteTransactionRequest is the transaction mute payload.
-type DocMuteTransactionRequest struct {
+// MuteTransactionRequest is the transaction mute payload.
+type MuteTransactionRequest struct {
 	Muted  bool   `json:"muted"`
 	Reason string `json:"reason,omitempty" example:"Internal transfer"`
 }
 
-// DocMuteTransactionResponse is the transaction mute response payload.
-type DocMuteTransactionResponse struct {
+// MuteTransactionResponse is the transaction mute response payload.
+type MuteTransactionResponse struct {
 	Muted  bool   `json:"muted"`
 	Reason string `json:"reason,omitempty" example:"Internal transfer"`
 }
 
-// DocUpdateMuteReasonRequest is the mute reason update payload.
-type DocUpdateMuteReasonRequest struct {
+// UpdateMuteReasonRequest is the mute reason update payload.
+type UpdateMuteReasonRequest struct {
 	Reason string `json:"reason" example:"Internal transfer"`
 }
 
-// DocMuteReasonResponse is the mute reason response payload.
-type DocMuteReasonResponse struct {
+// MuteReasonResponse is the mute reason response payload.
+type MuteReasonResponse struct {
 	Reason string `json:"reason" example:"Internal transfer"`
 }

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -84,127 +84,127 @@ func spaHandler(dir string) http.HandlerFunc {
 // registerRoutes attaches all API routes to mux.
 func registerRoutes(mux *http.ServeMux, h *Handlers) {
 	// Health, status & version
-	mux.HandleFunc("GET /api/health", h.HandleHealth)
-	mux.HandleFunc("GET /api/status", h.HandleStatus)
-	mux.HandleFunc("GET /api/version", h.HandleVersion)
-	mux.HandleFunc("POST /api/daemon/start", h.HandleStartDaemon)
-	mux.HandleFunc("POST /api/daemon/rescan", h.HandleRescan)
-	mux.HandleFunc("GET /api/config/active-reader", h.HandleGetActiveReader)
+	mux.HandleFunc("GET /api/health", h.Health)
+	mux.HandleFunc("GET /api/status", h.Status)
+	mux.HandleFunc("GET /api/version", h.Version)
+	mux.HandleFunc("POST /api/daemon/start", h.StartDaemon)
+	mux.HandleFunc("POST /api/daemon/rescan", h.Rescan)
+	mux.HandleFunc("GET /api/config/active-reader", h.GetActiveReader)
 
 	// Plugin listing
-	mux.HandleFunc("GET /api/plugins/readers", h.HandleListReaders)
-	mux.HandleFunc("GET /api/plugins/writers", h.HandleListWriters)
+	mux.HandleFunc("GET /api/plugins/readers", h.ListReaders)
+	mux.HandleFunc("GET /api/plugins/writers", h.ListWriters)
 
 	// Thunderbird profile/mailbox discovery (must precede wildcard /api/readers/{name}/... routes)
-	mux.HandleFunc("GET /api/readers/thunderbird/discover/profiles", h.HandleDiscoverProfiles)
-	mux.HandleFunc("GET /api/readers/thunderbird/discover/mailboxes", h.HandleDiscoverMailboxes)
+	mux.HandleFunc("GET /api/readers/thunderbird/discover/profiles", h.DiscoverProfiles)
+	mux.HandleFunc("GET /api/readers/thunderbird/discover/mailboxes", h.DiscoverMailboxes)
 
 	// Reader setup guide (must precede wildcard /api/readers/{name}/... routes)
-	mux.HandleFunc("GET /api/readers/{name}/guide", h.HandleGetReaderGuide)
+	mux.HandleFunc("GET /api/readers/{name}/guide", h.GetReaderGuide)
 
 	// Reader credentials (OAuth readers that need client_secret.json upload)
-	mux.HandleFunc("POST /api/readers/{name}/credentials", h.HandleUploadCredentials)
-	mux.HandleFunc("GET /api/readers/{name}/credentials/status", h.HandleCredentialsStatus)
+	mux.HandleFunc("POST /api/readers/{name}/credentials", h.UploadCredentials)
+	mux.HandleFunc("GET /api/readers/{name}/credentials/status", h.CredentialsStatus)
 
 	// OAuth flow
-	mux.HandleFunc("POST /api/readers/{name}/auth/start", h.HandleAuthStart)
-	mux.HandleFunc("GET /api/auth/callback", h.HandleAuthCallback)                 // shared redirect URI
-	mux.HandleFunc("POST /api/readers/{name}/auth/exchange", h.HandleAuthExchange) // manual paste flow for homeservers
-	mux.HandleFunc("GET /api/readers/{name}/auth/status", h.HandleAuthStatus)
-	mux.HandleFunc("DELETE /api/readers/{name}/auth/token", h.HandleRevokeToken)
+	mux.HandleFunc("POST /api/readers/{name}/auth/start", h.AuthStart)
+	mux.HandleFunc("GET /api/auth/callback", h.AuthCallback)                 // shared redirect URI
+	mux.HandleFunc("POST /api/readers/{name}/auth/exchange", h.AuthExchange) // manual paste flow for homeservers
+	mux.HandleFunc("GET /api/readers/{name}/auth/status", h.AuthStatus)
+	mux.HandleFunc("DELETE /api/readers/{name}/auth/token", h.RevokeToken)
 
 	// Reader config (config-only readers like Thunderbird, plus optional settings for OAuth readers)
-	mux.HandleFunc("GET /api/readers/{name}/config", h.HandleGetReaderConfig)
-	mux.HandleFunc("POST /api/readers/{name}/config", h.HandleSaveReaderConfig)
+	mux.HandleFunc("GET /api/readers/{name}/config", h.GetReaderConfig)
+	mux.HandleFunc("POST /api/readers/{name}/config", h.SaveReaderConfig)
 
 	// Reader overall readiness
-	mux.HandleFunc("GET /api/readers/{name}/status", h.HandleReaderStatus)
+	mux.HandleFunc("GET /api/readers/{name}/status", h.ReaderStatus)
 
 	// Full reader disconnect (removes all credentials/token/config files)
-	mux.HandleFunc("DELETE /api/readers/{name}", h.HandleDisconnectReader)
+	mux.HandleFunc("DELETE /api/readers/{name}", h.DisconnectReader)
 
 	// Chart data
-	mux.HandleFunc("GET /api/stats/dashboard", h.HandleGetDashboardData)
-	mux.HandleFunc("GET /api/stats/charts", h.HandleGetChartData)
-	mux.HandleFunc("GET /api/stats/labels/monthly", h.HandleGetLabelMonthlySpend)
-	mux.HandleFunc("GET /api/stats/heatmap", h.HandleGetHeatmap)
-	mux.HandleFunc("GET /api/stats/heatmap/annual", h.HandleGetAnnualHeatmap)
+	mux.HandleFunc("GET /api/stats/dashboard", h.GetDashboardData)
+	mux.HandleFunc("GET /api/stats/charts", h.GetChartData)
+	mux.HandleFunc("GET /api/stats/labels/monthly", h.GetLabelMonthlySpend)
+	mux.HandleFunc("GET /api/stats/heatmap", h.GetHeatmap)
+	mux.HandleFunc("GET /api/stats/heatmap/annual", h.GetAnnualHeatmap)
 
 	// App configuration
-	mux.HandleFunc("GET /api/config/banks", h.HandleListBanks)
-	mux.HandleFunc("GET /api/config/setup-status", h.HandleGetSetupStatus)
-	mux.HandleFunc("POST /api/config/sync", h.HandleTriggerSync)
-	mux.HandleFunc("GET /api/config/sync/status", h.HandleGetSyncStatus)
-	mux.HandleFunc("GET /api/config/base-currency", h.HandleGetBaseCurrency)
-	mux.HandleFunc("PUT /api/config/base-currency", h.HandleSetBaseCurrency)
-	mux.HandleFunc("GET /api/config/scan-interval", h.HandleGetScanInterval)
-	mux.HandleFunc("PUT /api/config/scan-interval", h.HandleSetScanInterval)
-	mux.HandleFunc("GET /api/config/lookback-days", h.HandleGetLookbackDays)
-	mux.HandleFunc("PUT /api/config/lookback-days", h.HandleSetLookbackDays)
-	mux.HandleFunc("GET /api/config/timezone", h.HandleGetTimezone)
-	mux.HandleFunc("PUT /api/config/timezone", h.HandleSetTimezone)
-	mux.HandleFunc("GET /api/config/time-format", h.HandleGetTimeFormat)
-	mux.HandleFunc("PUT /api/config/time-format", h.HandleSetTimeFormat)
-	mux.HandleFunc("GET /api/config/readers/{name}/checkpoint", h.HandleGetReaderCheckpoint)
-	mux.HandleFunc("DELETE /api/config/readers/{name}/checkpoint", h.HandleClearReaderCheckpoint)
+	mux.HandleFunc("GET /api/config/banks", h.ListBanks)
+	mux.HandleFunc("GET /api/config/setup-status", h.GetSetupStatus)
+	mux.HandleFunc("POST /api/config/sync", h.TriggerSync)
+	mux.HandleFunc("GET /api/config/sync/status", h.GetSyncStatus)
+	mux.HandleFunc("GET /api/config/base-currency", h.GetBaseCurrency)
+	mux.HandleFunc("PUT /api/config/base-currency", h.SetBaseCurrency)
+	mux.HandleFunc("GET /api/config/scan-interval", h.GetScanInterval)
+	mux.HandleFunc("PUT /api/config/scan-interval", h.SetScanInterval)
+	mux.HandleFunc("GET /api/config/lookback-days", h.GetLookbackDays)
+	mux.HandleFunc("PUT /api/config/lookback-days", h.SetLookbackDays)
+	mux.HandleFunc("GET /api/config/timezone", h.GetTimezone)
+	mux.HandleFunc("PUT /api/config/timezone", h.SetTimezone)
+	mux.HandleFunc("GET /api/config/time-format", h.GetTimeFormat)
+	mux.HandleFunc("PUT /api/config/time-format", h.SetTimeFormat)
+	mux.HandleFunc("GET /api/config/readers/{name}/checkpoint", h.GetReaderCheckpoint)
+	mux.HandleFunc("DELETE /api/config/readers/{name}/checkpoint", h.ClearReaderCheckpoint)
 
 	// Labels taxonomy
-	mux.HandleFunc("GET /api/config/labels/export", h.HandleExportLabels)       // must precede /{name}
-	mux.HandleFunc("GET /api/config/labels/mappings", h.HandleGetLabelMappings) // must precede /{name}
-	mux.HandleFunc("GET /api/config/labels", h.HandleListLabels)
-	mux.HandleFunc("POST /api/config/labels", h.HandleCreateLabel)
-	mux.HandleFunc("PUT /api/config/labels/{name}", h.HandleUpdateLabel)
-	mux.HandleFunc("DELETE /api/config/labels/{name}", h.HandleDeleteLabel)
-	mux.HandleFunc("POST /api/config/labels/{name}/apply", h.HandleApplyLabel)
-	mux.HandleFunc("DELETE /api/config/labels/{name}/merchant", h.HandleRemoveLabelByMerchant)
+	mux.HandleFunc("GET /api/config/labels/export", h.ExportLabels)       // must precede /{name}
+	mux.HandleFunc("GET /api/config/labels/mappings", h.GetLabelMappings) // must precede /{name}
+	mux.HandleFunc("GET /api/config/labels", h.ListLabels)
+	mux.HandleFunc("POST /api/config/labels", h.CreateLabel)
+	mux.HandleFunc("PUT /api/config/labels/{name}", h.UpdateLabel)
+	mux.HandleFunc("DELETE /api/config/labels/{name}", h.DeleteLabel)
+	mux.HandleFunc("POST /api/config/labels/{name}/apply", h.ApplyLabel)
+	mux.HandleFunc("DELETE /api/config/labels/{name}/merchant", h.RemoveLabelByMerchant)
 
 	// Categories and buckets
-	mux.HandleFunc("GET /api/config/categories/export", h.HandleExportCategories)      // must precede /{name}
-	mux.HandleFunc("GET /api/config/categories/mappings", h.HandleGetCategoryMappings) // must precede /{name}
-	mux.HandleFunc("GET /api/config/categories", h.HandleListCategories)
-	mux.HandleFunc("POST /api/config/categories", h.HandleCreateCategory)
-	mux.HandleFunc("DELETE /api/config/categories/{name}", h.HandleDeleteCategory)
-	mux.HandleFunc("POST /api/config/categories/{name}/apply", h.HandleApplyCategoryByMerchant)
-	mux.HandleFunc("DELETE /api/config/categories/{name}/merchant", h.HandleRemoveCategoryByMerchant)
-	mux.HandleFunc("GET /api/config/buckets/export", h.HandleExportBuckets)       // must precede /{name}
-	mux.HandleFunc("GET /api/config/buckets/mappings", h.HandleGetBucketMappings) // must precede /{name}
-	mux.HandleFunc("GET /api/config/buckets", h.HandleListBuckets)
-	mux.HandleFunc("POST /api/config/buckets", h.HandleCreateBucket)
-	mux.HandleFunc("DELETE /api/config/buckets/{name}", h.HandleDeleteBucket)
-	mux.HandleFunc("POST /api/config/buckets/{name}/apply", h.HandleApplyBucketByMerchant)
-	mux.HandleFunc("DELETE /api/config/buckets/{name}/merchant", h.HandleRemoveBucketByMerchant)
+	mux.HandleFunc("GET /api/config/categories/export", h.ExportCategories)      // must precede /{name}
+	mux.HandleFunc("GET /api/config/categories/mappings", h.GetCategoryMappings) // must precede /{name}
+	mux.HandleFunc("GET /api/config/categories", h.ListCategories)
+	mux.HandleFunc("POST /api/config/categories", h.CreateCategory)
+	mux.HandleFunc("DELETE /api/config/categories/{name}", h.DeleteCategory)
+	mux.HandleFunc("POST /api/config/categories/{name}/apply", h.ApplyCategoryByMerchant)
+	mux.HandleFunc("DELETE /api/config/categories/{name}/merchant", h.RemoveCategoryByMerchant)
+	mux.HandleFunc("GET /api/config/buckets/export", h.ExportBuckets)       // must precede /{name}
+	mux.HandleFunc("GET /api/config/buckets/mappings", h.GetBucketMappings) // must precede /{name}
+	mux.HandleFunc("GET /api/config/buckets", h.ListBuckets)
+	mux.HandleFunc("POST /api/config/buckets", h.CreateBucket)
+	mux.HandleFunc("DELETE /api/config/buckets/{name}", h.DeleteBucket)
+	mux.HandleFunc("POST /api/config/buckets/{name}/apply", h.ApplyBucketByMerchant)
+	mux.HandleFunc("DELETE /api/config/buckets/{name}/merchant", h.RemoveBucketByMerchant)
 
 	// Rules — export and import before /{id} to avoid wildcard capture
-	mux.HandleFunc("GET /api/rules", h.HandleListRules)
-	mux.HandleFunc("GET /api/rules/export", h.HandleExportRules)
-	mux.HandleFunc("POST /api/rules/import", h.HandleImportRules)
-	mux.HandleFunc("POST /api/rules", h.HandleCreateRule)
-	mux.HandleFunc("PUT /api/rules/{id}", h.HandleUpdateRule)
-	mux.HandleFunc("DELETE /api/rules/{id}", h.HandleDeleteRule)
+	mux.HandleFunc("GET /api/rules", h.ListRules)
+	mux.HandleFunc("GET /api/rules/export", h.ExportRules)
+	mux.HandleFunc("POST /api/rules/import", h.ImportRules)
+	mux.HandleFunc("POST /api/rules", h.CreateRule)
+	mux.HandleFunc("PUT /api/rules/{id}", h.UpdateRule)
+	mux.HandleFunc("DELETE /api/rules/{id}", h.DeleteRule)
 
 	// Transactions
 	// /search and /facets must be registered before /{id} to avoid the wildcard swallowing them.
-	mux.HandleFunc("GET /api/transactions/search", h.HandleSearchTransactions)
-	mux.HandleFunc("GET /api/transactions/facets", h.HandleGetFacets)
-	mux.HandleFunc("GET /api/transactions", h.HandleListTransactions)
-	mux.HandleFunc("GET /api/transactions/{id}", h.HandleGetTransaction)
-	mux.HandleFunc("PUT /api/transactions/{id}", h.HandleUpdateTransaction)
-	mux.HandleFunc("POST /api/transactions/{id}/labels", h.HandleAddLabels)
-	mux.HandleFunc("DELETE /api/transactions/{id}/labels/{label}", h.HandleRemoveLabel)
-	mux.HandleFunc("PUT /api/transactions/{id}/mute", h.HandleMuteTransaction)
-	mux.HandleFunc("PUT /api/transactions/{id}/mute-reason", h.HandleUpdateMuteReason)
+	mux.HandleFunc("GET /api/transactions/search", h.SearchTransactions)
+	mux.HandleFunc("GET /api/transactions/facets", h.GetFacets)
+	mux.HandleFunc("GET /api/transactions", h.ListTransactions)
+	mux.HandleFunc("GET /api/transactions/{id}", h.GetTransaction)
+	mux.HandleFunc("PUT /api/transactions/{id}", h.UpdateTransaction)
+	mux.HandleFunc("POST /api/transactions/{id}/labels", h.AddLabels)
+	mux.HandleFunc("DELETE /api/transactions/{id}/labels/{label}", h.RemoveLabel)
+	mux.HandleFunc("PUT /api/transactions/{id}/mute", h.MuteTransaction)
+	mux.HandleFunc("PUT /api/transactions/{id}/mute-reason", h.UpdateMuteReason)
 
 	// Extraction diagnostics
-	mux.HandleFunc("GET /api/extraction-diagnostics", h.HandleListExtractionDiagnostics)
-	mux.HandleFunc("GET /api/extraction-diagnostics/{id}", h.HandleGetExtractionDiagnostic)
-	mux.HandleFunc("PUT /api/extraction-diagnostics/{id}/status", h.HandleUpdateExtractionDiagnosticStatus)
+	mux.HandleFunc("GET /api/extraction-diagnostics", h.ListExtractionDiagnostics)
+	mux.HandleFunc("GET /api/extraction-diagnostics/{id}", h.GetExtractionDiagnostic)
+	mux.HandleFunc("PUT /api/extraction-diagnostics/{id}/status", h.UpdateExtractionDiagnosticStatus)
 
 	// Muted merchants
-	mux.HandleFunc("GET /api/muted-merchants", h.HandleListMutedMerchants)
-	mux.HandleFunc("POST /api/muted-merchants", h.HandleMuteByMerchant)
-	mux.HandleFunc("PUT /api/muted-merchants/{id}/reason", h.HandleUpdateMerchantReason)
-	mux.HandleFunc("DELETE /api/muted-merchants/{id}", h.HandleDeleteMutedMerchant)
+	mux.HandleFunc("GET /api/muted-merchants", h.ListMutedMerchants)
+	mux.HandleFunc("POST /api/muted-merchants", h.MuteByMerchant)
+	mux.HandleFunc("PUT /api/muted-merchants/{id}/reason", h.UpdateMerchantReason)
+	mux.HandleFunc("DELETE /api/muted-merchants/{id}", h.DeleteMutedMerchant)
 
 	// Merchant-wide categorization
-	mux.HandleFunc("POST /api/merchants/categorize", h.HandleCategorizeMerchant)
+	mux.HandleFunc("POST /api/merchants/categorize", h.CategorizeMerchant)
 }


### PR DESCRIPTION
## Description

Clean up backend API naming after the handler decomposition slice. This removes redundant `Handle` prefixes from `Handlers` receiver methods and removes the `Doc` prefix from OpenAPI-only DTO names while preserving routes, JSON fields, and handler behavior.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

<!-- Link to the related issue(s) -->

Part of backend observability and code-health follow-up work.

## Changes Made

<!-- List the changes you made -->

- Rename `(*Handlers).Handle*` methods to resource/action names and update route wiring plus direct handler tests.
- Rename OpenAPI DTOs from `Doc*` to plain request/response names and regenerate the committed OpenAPI artifact.
- Rename the unexported base-currency helper to avoid a strict-lint naming collision with `GetBaseCurrency`.

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass (`task test:be`)
- [x] Linter passes (`task lint:be:prod` and `task lint:fe`)
- [ ] Manual testing completed
- [ ] Added new tests (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

`task openapi:check` was run after regeneration. It reports the expected OpenAPI artifact diff against `main` because schema component names changed from `api.Doc*` to `api.*`; route paths and payload fields are unchanged.
