### PR TITLE
Finish backend observability cleanup

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -861,6 +861,19 @@ func syncCommunityContent(ctx context.Context, st httpapi.Storer, baseURL string
 	if baseURL == "" {
 		return
 	}
+	scope := observability.NewScope(logger, "github.com/ArionMiles/expensor/backend/cmd/server/community_sync")
+	ctx, span := scope.Start(ctx, "community_sync.sync")
+	defer span.End()
+	start := time.Now()
+	var syncErr error
+	defer func() {
+		scope.RecordDuration(ctx, observability.DurationOperation{
+			Namespace: "community_sync",
+			Name:      "sync",
+			Duration:  time.Since(start),
+			Err:       syncErr,
+		})
+	}()
 	logger.Info("syncing community content", "url", baseURL)
 
 	fetchJSON := func(path string, dest any) error {
@@ -882,21 +895,25 @@ func syncCommunityContent(ctx context.Context, st httpapi.Storer, baseURL string
 
 	var mccEntries []store.MCCEntry
 	if err := fetchJSON("mcc.json", &mccEntries); err != nil {
+		syncErr = err
 		recordSyncError(ctx, st, err, logger)
 		return
 	}
 	var catEntries []store.MerchantCategoryEntry
 	if err := fetchJSON("categories.json", &catEntries); err != nil {
+		syncErr = err
 		recordSyncError(ctx, st, err, logger)
 		return
 	}
 
 	if err := st.SeedMCCCodes(ctx, mccEntries); err != nil {
+		syncErr = err
 		recordSyncError(ctx, st, err, logger)
 		return
 	}
 	updated, err := st.SeedMerchantCategories(ctx, catEntries)
 	if err != nil {
+		syncErr = err
 		recordSyncError(ctx, st, err, logger)
 		return
 	}

--- a/backend/internal/api/middleware.go
+++ b/backend/internal/api/middleware.go
@@ -4,6 +4,10 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/ArionMiles/expensor/backend/pkg/observability"
 )
 
 // loggingMiddleware logs method, path, status, and duration for every request.
@@ -18,6 +22,42 @@ func loggingMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
 			"status", rw.status,
 			"duration_ms", time.Since(start).Milliseconds(),
 		)
+	})
+}
+
+// observabilityMiddleware records low-cardinality HTTP request telemetry.
+func observabilityMiddleware(scope *observability.Scope, next http.Handler) http.Handler {
+	if scope == nil {
+		scope = observability.NewScope(slog.Default(), "github.com/ArionMiles/expensor/backend/internal/api")
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := scope.Start(r.Context(), "http.server.request")
+		defer span.End()
+
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
+		req := r.WithContext(ctx)
+		next.ServeHTTP(rw, req)
+
+		route := req.Pattern
+		if route == "" {
+			route = "unmatched"
+		}
+		span.SetAttributes(
+			attribute.String("http.request.method", r.Method),
+			attribute.String("http.route", route),
+			attribute.Int("http.response.status_code", rw.status),
+		)
+		scope.RecordDuration(ctx, observability.DurationOperation{
+			Namespace:  "http",
+			Name:       "server.request",
+			Duration:   time.Since(start),
+			StatusCode: rw.status,
+			Attributes: []attribute.KeyValue{
+				attribute.String("method", r.Method),
+				attribute.String("route", route),
+			},
+		})
 	})
 }
 

--- a/backend/internal/api/middleware_test.go
+++ b/backend/internal/api/middleware_test.go
@@ -2,11 +2,19 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/ArionMiles/expensor/backend/pkg/observability"
 )
 
 func TestRecoveryMiddlewareContentType(t *testing.T) {
@@ -35,5 +43,55 @@ func TestRecoveryMiddlewareContentType(t *testing.T) {
 	}
 	if _, ok := body["error"]; !ok {
 		t.Errorf("expected JSON body to contain 'error' key, got %v", body)
+	}
+}
+
+func TestObservabilityMiddlewareCreatesHTTPRequestSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(t.Context())
+		otel.SetTracerProvider(noop.NewTracerProvider())
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/transactions/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scope := observability.NewScope(logger, "test/http")
+	handler := observabilityMiddleware(scope, mux)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/transactions/123", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusAccepted)
+	}
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Name() != "http.server.request" {
+		t.Fatalf("span name = %q, want http.server.request", spans[0].Name())
+	}
+	attrs := spans[0].Attributes()
+	wantAttrs := map[string]string{
+		"http.request.method": "GET",
+		"http.route":          "GET /api/transactions/{id}",
+	}
+	for key, want := range wantAttrs {
+		found := false
+		for _, attr := range attrs {
+			if string(attr.Key) == key && attr.Value.AsString() == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("span attributes missing %s=%q: %#v", key, want, attrs)
+		}
 	}
 }

--- a/backend/internal/api/server.go
+++ b/backend/internal/api/server.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"path/filepath"
 	"time"
+
+	"github.com/ArionMiles/expensor/backend/pkg/observability"
 )
 
 // Server wraps the HTTP server and its dependencies.
@@ -28,7 +30,8 @@ func NewServer(port int, handlers *Handlers, staticDir string, logger *slog.Logg
 		mux.HandleFunc("/", spaHandler(staticDir))
 	}
 
-	chain := corsMiddleware(loggingMiddleware(logger, recoveryMiddleware(logger, mux)))
+	scope := observability.NewScope(logger, "github.com/ArionMiles/expensor/backend/internal/api")
+	chain := corsMiddleware(loggingMiddleware(logger, observabilityMiddleware(scope, recoveryMiddleware(logger, mux))))
 
 	return &Server{
 		httpServer: &http.Server{

--- a/backend/internal/daemon/runner.go
+++ b/backend/internal/daemon/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
+	"github.com/ArionMiles/expensor/backend/pkg/observability"
 	"github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
@@ -23,18 +24,28 @@ type Runner struct {
 	registry   *plugins.Registry
 	httpClient *http.Client
 	logger     *slog.Logger
+	scope      *observability.Scope
 }
 
 // New creates a new daemon runner.
 func New(registry *plugins.Registry, httpClient *http.Client, logger *slog.Logger) *Runner {
+	return NewWithScope(registry, httpClient, logger, nil)
+}
+
+// NewWithScope creates a daemon runner with an explicit observability scope.
+func NewWithScope(registry *plugins.Registry, httpClient *http.Client, logger *slog.Logger, scope *observability.Scope) *Runner {
 	if logger == nil {
 		logger = slog.Default()
+	}
+	if scope == nil {
+		scope = observability.NewScope(logger, "github.com/ArionMiles/expensor/backend/internal/daemon")
 	}
 
 	return &Runner{
 		registry:   registry,
 		httpClient: httpClient,
 		logger:     logger,
+		scope:      scope,
 	}
 }
 
@@ -64,7 +75,18 @@ type ReaderRuntimeStore interface {
 // Run starts the expense tracking daemon with the given configuration.
 // It blocks until the context is canceled or an error occurs.
 func (r *Runner) Run(ctx context.Context, runCfg RunConfig) error {
+	ctx, span := r.scope.Start(ctx, "daemon.run")
+	defer span.End()
+
 	cfg := runCfg.Config
+	var runErr error
+	defer func() {
+		r.scope.RecordOperation(ctx, observability.Operation{
+			Namespace: "daemon",
+			Name:      "run",
+			Err:       runErr,
+		})
+	}()
 
 	r.logger.Info("starting expensor daemon",
 		"reader", runCfg.ReaderName,
@@ -73,6 +95,7 @@ func (r *Runner) Run(ctx context.Context, runCfg RunConfig) error {
 
 	readerPlugin, err := r.registry.GetReader(runCfg.ReaderName)
 	if err != nil {
+		runErr = err
 		return fmt.Errorf("creating reader: %w", err)
 	}
 	reader, err := readerPlugin.NewReader(plugins.ReaderInput{
@@ -86,11 +109,13 @@ func (r *Runner) Run(ctx context.Context, runCfg RunConfig) error {
 		Logger:         r.logger.With("component", "reader", "plugin", runCfg.ReaderName),
 	})
 	if err != nil {
+		runErr = err
 		return fmt.Errorf("creating reader: %w", err)
 	}
 
 	writerPlugin, err := r.registry.GetWriter(runCfg.WriterName)
 	if err != nil {
+		runErr = err
 		return fmt.Errorf("creating writer: %w", err)
 	}
 	writer, err := writerPlugin.NewWriter(plugins.WriterInput{
@@ -99,6 +124,7 @@ func (r *Runner) Run(ctx context.Context, runCfg RunConfig) error {
 		Logger:     r.logger.With("component", "writer", "plugin", runCfg.WriterName),
 	})
 	if err != nil {
+		runErr = err
 		return fmt.Errorf("creating writer: %w", err)
 	}
 
@@ -115,6 +141,7 @@ func (r *Runner) Run(ctx context.Context, runCfg RunConfig) error {
 	if err := g.Wait(); err != nil &&
 		!errors.Is(err, context.Canceled) &&
 		!errors.Is(err, context.DeadlineExceeded) {
+		runErr = err
 		r.logger.Error("daemon error", "error", err)
 	}
 

--- a/backend/internal/daemon/runner_test.go
+++ b/backend/internal/daemon/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -12,9 +13,15 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+
 	"github.com/ArionMiles/expensor/backend/internal/plugins"
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/config"
+	"github.com/ArionMiles/expensor/backend/pkg/observability"
 )
 
 // mockReader implements api.Reader for testing.
@@ -149,6 +156,44 @@ func TestNew(t *testing.T) {
 				t.Error("expected logger to be set (default if nil)")
 			}
 		})
+	}
+}
+
+func TestRunCreatesDaemonLifecycleSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(t.Context())
+		otel.SetTracerProvider(noop.NewTracerProvider())
+	})
+
+	registry := plugins.NewRegistry()
+	if err := registry.RegisterReader(&mockReaderPlugin{name: "test-reader", reader: &mockReader{}}); err != nil {
+		t.Fatalf("RegisterReader() error = %v", err)
+	}
+	if err := registry.RegisterWriter(&mockWriterPlugin{name: "test-writer", writer: &mockWriter{}}); err != nil {
+		t.Fatalf("RegisterWriter() error = %v", err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scope := observability.NewScope(logger, "test/daemon")
+	runner := NewWithScope(registry, &http.Client{}, logger, scope)
+
+	err := runner.Run(t.Context(), RunConfig{
+		ReaderName: "test-reader",
+		WriterName: "test-writer",
+		Config:     &config.Config{},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(spans))
+	}
+	if spans[0].Name() != "daemon.run" {
+		t.Fatalf("span name = %q, want daemon.run", spans[0].Name())
 	}
 }
 

--- a/backend/internal/store/community_repository.go
+++ b/backend/internal/store/community_repository.go
@@ -35,6 +35,10 @@ type categorySnapshotEntry struct {
 }
 
 func NewCommunityRepository(deps repositoryDependencies) CommunityRepository {
+	return newPGCommunityRepository(deps)
+}
+
+func newPGCommunityRepository(deps repositoryDependencies) *pgCommunityRepository {
 	return &pgCommunityRepository{
 		pool: deps.pool,
 	}

--- a/backend/internal/store/diagnostics_repository.go
+++ b/backend/internal/store/diagnostics_repository.go
@@ -21,6 +21,10 @@ type pgDiagnosticsRepository struct {
 }
 
 func NewDiagnosticsRepository(deps repositoryDependencies) DiagnosticsRepository {
+	return newPGDiagnosticsRepository(deps)
+}
+
+func newPGDiagnosticsRepository(deps repositoryDependencies) *pgDiagnosticsRepository {
 	return &pgDiagnosticsRepository{
 		pool: deps.pool,
 	}

--- a/backend/internal/store/label_repository.go
+++ b/backend/internal/store/label_repository.go
@@ -49,6 +49,10 @@ type taxonomyItem struct {
 
 // NewTaxonomyRepository returns a PostgreSQL-backed taxonomy repository.
 func NewTaxonomyRepository(deps repositoryDependencies) TaxonomyRepository {
+	return newPGTaxonomyRepository(deps)
+}
+
+func newPGTaxonomyRepository(deps repositoryDependencies) *pgTaxonomyRepository {
 	return &pgTaxonomyRepository{
 		pool: deps.pool,
 	}

--- a/backend/internal/store/read_model_repository.go
+++ b/backend/internal/store/read_model_repository.go
@@ -27,6 +27,10 @@ type pgReadModelRepository struct {
 }
 
 func NewReadModelRepository(deps repositoryDependencies, runtime RuntimeRepository) ReadModelRepository {
+	return newPGReadModelRepository(deps, runtime)
+}
+
+func newPGReadModelRepository(deps repositoryDependencies, runtime RuntimeRepository) *pgReadModelRepository {
 	return &pgReadModelRepository{
 		pool:    deps.pool,
 		runtime: runtime,

--- a/backend/internal/store/read_model_repository_ownership_test.go
+++ b/backend/internal/store/read_model_repository_ownership_test.go
@@ -11,3 +11,17 @@ func TestReadModelRepositoryDoesNotKeepLegacyStoreBackReference(t *testing.T) {
 		t.Fatal("pgReadModelRepository should receive explicit dependencies instead of a legacy *Store back-reference")
 	}
 }
+
+func TestStoreKeepsSingleImplementationRepositoriesConcrete(t *testing.T) {
+	storeType := reflect.TypeOf(Store{})
+	wantConcreteFields := []string{"community", "diag", "readModel", "rules", "runtime", "taxonomy", "txns"}
+	for _, name := range wantConcreteFields {
+		field, ok := storeType.FieldByName(name)
+		if !ok {
+			t.Fatalf("Store missing field %q", name)
+		}
+		if field.Type.Kind() == reflect.Interface {
+			t.Fatalf("Store.%s is %s; single-implementation repositories should be concrete private fields", name, field.Type)
+		}
+	}
+}

--- a/backend/internal/store/rules_repository.go
+++ b/backend/internal/store/rules_repository.go
@@ -23,6 +23,10 @@ type pgRulesRepository struct {
 }
 
 func NewRulesRepository(deps repositoryDependencies) RulesRepository {
+	return newPGRulesRepository(deps)
+}
+
+func newPGRulesRepository(deps repositoryDependencies) *pgRulesRepository {
 	return &pgRulesRepository{
 		pool: deps.pool,
 	}

--- a/backend/internal/store/runtime_repository.go
+++ b/backend/internal/store/runtime_repository.go
@@ -45,6 +45,10 @@ type pgRuntimeRepository struct {
 }
 
 func NewRuntimeRepository(deps repositoryDependencies) RuntimeRepository {
+	return newPGRuntimeRepository(deps)
+}
+
+func newPGRuntimeRepository(deps repositoryDependencies) *pgRuntimeRepository {
 	return &pgRuntimeRepository{
 		pool: deps.pool,
 	}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -6,7 +6,6 @@ package store
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -23,13 +22,13 @@ type Store struct {
 	pool      *pgxpool.Pool
 	logger    *slog.Logger
 	now       func() time.Time
-	community CommunityRepository
-	diag      DiagnosticsRepository
-	readModel ReadModelRepository
-	rules     RulesRepository
-	runtime   RuntimeRepository
-	taxonomy  TaxonomyRepository
-	txns      TransactionsRepository
+	community *pgCommunityRepository
+	diag      *pgDiagnosticsRepository
+	readModel *pgReadModelRepository
+	rules     *pgRulesRepository
+	runtime   *pgRuntimeRepository
+	taxonomy  *pgTaxonomyRepository
+	txns      *pgTransactionsRepository
 }
 
 var _ api.DiagnosticSink = (*Store)(nil)
@@ -97,13 +96,13 @@ func (s *Store) initRepositories() {
 		logger: s.logger,
 		now:    s.now,
 	}
-	s.community = NewCommunityRepository(deps)
-	s.diag = NewDiagnosticsRepository(deps)
-	s.rules = NewRulesRepository(deps)
-	s.runtime = NewRuntimeRepository(deps)
-	s.readModel = NewReadModelRepository(deps, s.runtime)
-	s.taxonomy = NewTaxonomyRepository(deps)
-	s.txns = NewTransactionsRepository(deps)
+	s.community = newPGCommunityRepository(deps)
+	s.diag = newPGDiagnosticsRepository(deps)
+	s.rules = newPGRulesRepository(deps)
+	s.runtime = newPGRuntimeRepository(deps)
+	s.readModel = newPGReadModelRepository(deps, s.runtime)
+	s.taxonomy = newPGTaxonomyRepository(deps)
+	s.txns = newPGTransactionsRepository(deps)
 }
 
 // Close releases the store's connection pool.
@@ -117,11 +116,7 @@ func (s *Store) queryTransactionTotals(
 	where string,
 	args []any,
 ) (TransactionListResult, error) {
-	repo, ok := s.txns.(*pgTransactionsRepository)
-	if !ok {
-		return TransactionListResult{}, errors.New("transactions repository unavailable")
-	}
-	return repo.queryTransactionTotals(ctx, join, where, args)
+	return s.txns.queryTransactionTotals(ctx, join, where, args)
 }
 
 // ListTransactions returns a paginated, filtered list of transactions and the total
@@ -557,11 +552,7 @@ func (s *Store) GetMutedMerchantPatterns(ctx context.Context) ([]string, error) 
 }
 
 func (s *Store) loadLabels(ctx context.Context, txns []Transaction) error {
-	repo, ok := s.txns.(*pgTransactionsRepository)
-	if !ok {
-		return errors.New("transactions repository unavailable")
-	}
-	return repo.loadLabels(ctx, txns)
+	return s.txns.loadLabels(ctx, txns)
 }
 
 // SeedMCCCodes upserts all MCC codes. Community content is authoritative for

--- a/backend/internal/store/testing.go
+++ b/backend/internal/store/testing.go
@@ -68,14 +68,13 @@ func (s *Store) PoolForTest() *pgxpool.Pool {
 func (s *Store) SetNowForTestSequence(seq ...time.Time) func() {
 	prev := s.now
 	var prevReadModelNow func() time.Time
-	readModel, _ := s.readModel.(*pgReadModelRepository)
-	if readModel != nil {
-		prevReadModelNow = readModel.now
+	if s.readModel != nil {
+		prevReadModelNow = s.readModel.now
 	}
 	if len(seq) == 0 {
 		s.now = prev
-		if readModel != nil {
-			readModel.now = prevReadModelNow
+		if s.readModel != nil {
+			s.readModel.now = prevReadModelNow
 		}
 		return func() {}
 	}
@@ -92,14 +91,14 @@ func (s *Store) SetNowForTestSequence(seq ...time.Time) func() {
 		idx++
 		return v
 	}
-	if readModel != nil {
-		readModel.now = s.now
+	if s.readModel != nil {
+		s.readModel.now = s.now
 	}
 
 	return func() {
 		s.now = prev
-		if readModel != nil {
-			readModel.now = prevReadModelNow
+		if s.readModel != nil {
+			s.readModel.now = prevReadModelNow
 		}
 	}
 }

--- a/backend/internal/store/transactions_repository.go
+++ b/backend/internal/store/transactions_repository.go
@@ -38,6 +38,10 @@ type pgTransactionsRepository struct {
 }
 
 func NewTransactionsRepository(deps repositoryDependencies) TransactionsRepository {
+	return newPGTransactionsRepository(deps)
+}
+
+func newPGTransactionsRepository(deps repositoryDependencies) *pgTransactionsRepository {
 	return &pgTransactionsRepository{
 		pool: deps.pool,
 	}

--- a/backend/pkg/observability/store.go
+++ b/backend/pkg/observability/store.go
@@ -3,12 +3,15 @@ package observability
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
+
+const errorStatus = "error"
 
 // Operation describes one low-cardinality operation measurement.
 type Operation struct {
@@ -17,11 +20,21 @@ type Operation struct {
 	Err       error
 }
 
+// DurationOperation describes one low-cardinality duration measurement.
+type DurationOperation struct {
+	Namespace  string
+	Name       string
+	Duration   time.Duration
+	StatusCode int
+	Err        error
+	Attributes []attribute.KeyValue
+}
+
 // RecordOperation records a span result, metrics, and a trace-aware log entry.
 func (s *Scope) RecordOperation(ctx context.Context, op Operation) {
 	status := "ok"
 	if op.Err != nil {
-		status = "error"
+		status = errorStatus
 	}
 
 	attrs := []attribute.KeyValue{
@@ -46,11 +59,38 @@ func (s *Scope) RecordOperation(ctx context.Context, op Operation) {
 	}
 
 	if op.Err != nil {
-		span.SetStatus(codes.Error, "error")
+		span.SetStatus(codes.Error, errorStatus)
 		logAttrs = append(logAttrs, slog.Any("error", op.Err))
 		s.logger.LogAttrs(ctx, slog.LevelError, "operation failed", logAttrs...)
 		return
 	}
 
 	s.logger.LogAttrs(ctx, slog.LevelDebug, "operation completed", logAttrs...)
+}
+
+// RecordDuration records request or batch latency with low-cardinality attributes.
+func (s *Scope) RecordDuration(ctx context.Context, op DurationOperation) {
+	status := "ok"
+	if op.Err != nil || op.StatusCode >= 500 {
+		status = errorStatus
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("namespace", op.Namespace),
+		attribute.String("operation", op.Name),
+		attribute.String("status", status),
+	}
+	attrs = append(attrs, op.Attributes...)
+	if op.StatusCode > 0 {
+		attrs = append(attrs, attribute.Int("status_code", op.StatusCode))
+	}
+
+	counter, _ := s.meter.Int64Counter(op.Namespace + ".operations")
+	counter.Add(ctx, 1, metric.WithAttributes(attrs...))
+	histogram, _ := s.meter.Float64Histogram(op.Namespace + ".duration_ms")
+	histogram.Record(ctx, float64(op.Duration.Milliseconds()), metric.WithAttributes(attrs...))
+
+	span := trace.SpanFromContext(ctx)
+	if status == errorStatus {
+		span.SetStatus(codes.Error, errorStatus)
+	}
 }

--- a/backend/pkg/reader/gmail/gmail.go
+++ b/backend/pkg/reader/gmail/gmail.go
@@ -14,12 +14,14 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/extractor"
+	"github.com/ArionMiles/expensor/backend/pkg/observability"
 	"github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
@@ -38,6 +40,7 @@ type Reader struct {
 	diagnosticSlots     chan struct{}
 	diagnosticSlotsOnce sync.Once
 	logger              *slog.Logger
+	scope               *observability.Scope
 }
 
 // Config holds configuration for the Gmail reader.
@@ -65,6 +68,8 @@ type Config struct {
 	State *state.Manager
 	// DiagnosticSink records best-effort extraction diagnostics.
 	DiagnosticSink api.DiagnosticSink
+	// ObservabilityScope records reader telemetry. Defaults to a Gmail reader scope.
+	ObservabilityScope *observability.Scope
 }
 
 // New creates a new Gmail reader.
@@ -103,7 +108,22 @@ func New(httpClient *http.Client, cfg Config, logger *slog.Logger) (*Reader, err
 		diagnosticSink:  cfg.DiagnosticSink,
 		diagnosticSlots: make(chan struct{}, maxConcurrentDiagnostics),
 		logger:          logger,
+		scope:           readerScope(cfg.ObservabilityScope, logger),
 	}, nil
+}
+
+func readerScope(scope *observability.Scope, logger *slog.Logger) *observability.Scope {
+	if scope != nil {
+		return scope
+	}
+	return observability.NewScope(logger, "github.com/ArionMiles/expensor/backend/pkg/reader/gmail")
+}
+
+func (r *Reader) observabilityScope() *observability.Scope {
+	if r.scope == nil {
+		r.scope = readerScope(nil, r.logger)
+	}
+	return r.scope
 }
 
 // Read continuously evaluates rules and sends extracted transactions to the output channel.
@@ -199,6 +219,9 @@ const (
 )
 
 func (r *Reader) evaluateRules(ctx context.Context, out chan<- *api.TransactionDetails) error {
+	ctx, span := r.observabilityScope().Start(ctx, "gmail.scan")
+	defer span.End()
+
 	r.logger.Info("starting rule evaluation", "rule_count", len(r.rules))
 
 	sem := make(chan struct{}, maxConcurrentRules)
@@ -229,10 +252,15 @@ func (r *Reader) evaluateRules(ctx context.Context, out chan<- *api.TransactionD
 	for err := range errCh {
 		ruleErrs = append(ruleErrs, err)
 	}
-	return errors.Join(ruleErrs...)
+	err := errors.Join(ruleErrs...)
+	r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "gmail", Name: "scan", Err: err})
+	return err
 }
 
 func (r *Reader) processRule(ctx context.Context, rule api.Rule, out chan<- *api.TransactionDetails) error {
+	ctx, span := r.observabilityScope().Start(ctx, "gmail.rule")
+	defer span.End()
+
 	logger := r.logger.With("rule", rule.Name, "source", rule.Source)
 	queries := r.buildRuleQueries(rule, logger)
 
@@ -260,8 +288,11 @@ func (r *Reader) processRule(ctx context.Context, rule api.Rule, out chan<- *api
 		}
 	}
 
+	err := errors.Join(messageErrs...)
+	span.SetAttributes(attribute.Int("gmail.messages_processed", totalFound))
+	r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "gmail", Name: "rule", Err: err})
 	logger.Info("rule processing complete", "rule", rule.Name, "messages_processed", totalFound)
-	return errors.Join(messageErrs...)
+	return err
 }
 
 func (r *Reader) buildRuleQuery(rule api.Rule, logger *slog.Logger) string {
@@ -335,6 +366,8 @@ func (r *Reader) listMessagesPage(ctx context.Context, query, pageToken string) 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	ctx, span := r.observabilityScope().Start(ctx, "gmail.messages.list")
+	defer span.End()
 
 	var resp *gmail.ListMessagesResponse
 	err := doWithAuthRetry(func() error {
@@ -346,6 +379,7 @@ func (r *Reader) listMessagesPage(ctx context.Context, query, pageToken string) 
 		resp, callErr = req.Do()
 		return callErr
 	})
+	r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "gmail", Name: "messages.list", Err: err})
 	return resp, err
 }
 
@@ -389,11 +423,15 @@ func (r *Reader) shouldSkipMessage(ctx context.Context, msgID string, logger *sl
 	if r.state == nil || !r.state.IsProcessed(ctx, msgID) {
 		return false
 	}
+	r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "gmail", Name: "messages.skipped"})
 	logger.Debug("skipping already processed message", "message_id", msgID)
 	return true
 }
 
 func (r *Reader) processMessage(ctx context.Context, msgID string, rule api.Rule, out chan<- *api.TransactionDetails) error {
+	ctx, span := r.observabilityScope().Start(ctx, "gmail.messages.get")
+	defer span.End()
+
 	var msg *gmail.Message
 	err := doWithAuthRetry(func() error {
 		var callErr error
@@ -401,6 +439,7 @@ func (r *Reader) processMessage(ctx context.Context, msgID string, rule api.Rule
 		return callErr
 	})
 	if err != nil {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "gmail", Name: "messages.get", Err: err})
 		return fmt.Errorf("getting message: %w", err)
 	}
 
@@ -443,19 +482,23 @@ func (r *Reader) processMessage(ctx context.Context, msgID string, rule api.Rule
 	// Message will be marked as processed only after successful write and acknowledgment
 	select {
 	case <-ctx.Done():
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "gmail", Name: "messages.get", Err: ctx.Err()})
 		return ctx.Err()
 	case out <- transaction:
 	}
 
+	r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "gmail", Name: "messages.get"})
 	return nil
 }
 
 func (r *Reader) recordExtractionDiagnostic(ctx context.Context, diagnostic api.ExtractionDiagnostic) {
 	if r.diagnosticSink == nil || len(diagnostic.FailureReasons) == 0 {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "diagnostics", Name: "skipped"})
 		return
 	}
 	release, ok := r.acquireDiagnosticSlot()
 	if !ok {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "diagnostics", Name: "skipped"})
 		r.diagnosticLogger().Warn("skipping extraction diagnostic; diagnostic recorder is saturated",
 			"reader", diagnostic.Reader, "message_id", diagnostic.MessageID)
 		return
@@ -466,7 +509,11 @@ func (r *Reader) recordExtractionDiagnostic(ctx context.Context, diagnostic api.
 		defer release()
 		diagnosticCtx, cancel := context.WithTimeout(ctx, diagnosticRecordTimeout)
 		defer cancel()
-		if err := sink.RecordExtractionDiagnostic(diagnosticCtx, diagnostic); err != nil {
+		diagnosticCtx, span := r.observabilityScope().Start(diagnosticCtx, "diagnostics.record")
+		err := sink.RecordExtractionDiagnostic(diagnosticCtx, diagnostic)
+		r.observabilityScope().RecordOperation(diagnosticCtx, observability.Operation{Namespace: "diagnostics", Name: "record", Err: err})
+		span.End()
+		if err != nil {
 			if logger == nil {
 				logger = slog.Default()
 			}

--- a/backend/pkg/reader/thunderbird/thunderbird.go
+++ b/backend/pkg/reader/thunderbird/thunderbird.go
@@ -13,9 +13,11 @@ import (
 	"time"
 
 	"github.com/emersion/go-mbox"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/ArionMiles/expensor/backend/pkg/api"
 	"github.com/ArionMiles/expensor/backend/pkg/extractor"
+	"github.com/ArionMiles/expensor/backend/pkg/observability"
 	"github.com/ArionMiles/expensor/backend/pkg/state"
 )
 
@@ -33,6 +35,7 @@ type Reader struct {
 	diagnosticSlots     chan struct{}
 	diagnosticSlotsOnce sync.Once
 	logger              *slog.Logger
+	scope               *observability.Scope
 }
 
 const (
@@ -62,6 +65,8 @@ type Config struct {
 	OnCheckpoint func(time.Time)
 	// DiagnosticSink records best-effort extraction diagnostics.
 	DiagnosticSink api.DiagnosticSink
+	// ObservabilityScope records reader telemetry. Defaults to a Thunderbird reader scope.
+	ObservabilityScope *observability.Scope
 }
 
 // New creates a new Thunderbird reader.
@@ -95,7 +100,22 @@ func New(cfg Config, logger *slog.Logger) (*Reader, error) {
 		diagnosticSink:  cfg.DiagnosticSink,
 		diagnosticSlots: make(chan struct{}, maxConcurrentDiagnostics),
 		logger:          logger,
+		scope:           readerScope(cfg.ObservabilityScope, logger),
 	}, nil
+}
+
+func readerScope(scope *observability.Scope, logger *slog.Logger) *observability.Scope {
+	if scope != nil {
+		return scope
+	}
+	return observability.NewScope(logger, "github.com/ArionMiles/expensor/backend/pkg/reader/thunderbird")
+}
+
+func (r *Reader) observabilityScope() *observability.Scope {
+	if r.scope == nil {
+		r.scope = readerScope(nil, r.logger)
+	}
+	return r.scope
 }
 
 // Read continuously scans mailboxes and sends extracted transactions to the output channel.
@@ -183,12 +203,20 @@ func (r *Reader) handleAcknowledgments(ctx context.Context, ackChan <-chan strin
 
 // scanAllMailboxes scans all configured mailboxes for new transactions.
 func (r *Reader) scanAllMailboxes(ctx context.Context, out chan<- *api.TransactionDetails) error {
+	ctx, span := r.observabilityScope().Start(ctx, "thunderbird.scan")
+	defer span.End()
+
 	r.logger.Info("starting mailbox scan", "mailbox_count", len(r.mailboxPaths))
+	var scanErr error
+	defer func() {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "scan", Err: scanErr})
+	}()
 
 	for mailboxName, mailboxPath := range r.mailboxPaths {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			scanErr = ctx.Err()
+			return scanErr
 		default:
 		}
 
@@ -204,6 +232,9 @@ func (r *Reader) scanAllMailboxes(ctx context.Context, out chan<- *api.Transacti
 
 // scanMailbox scans a single mailbox for transactions.
 func (r *Reader) scanMailbox(ctx context.Context, mailboxName, mailboxPath string, out chan<- *api.TransactionDetails) error {
+	ctx, span := r.observabilityScope().Start(ctx, "thunderbird.mailbox.scan")
+	defer span.End()
+
 	logger := r.logger.With("mailbox", mailboxName, "path", mailboxPath)
 
 	file, err := os.Open(mailboxPath)
@@ -219,7 +250,9 @@ func (r *Reader) scanMailbox(ctx context.Context, mailboxName, mailboxPath strin
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			err := ctx.Err()
+			r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "mailbox.scan", Err: err})
+			return err
 		default:
 		}
 
@@ -250,6 +283,11 @@ func (r *Reader) scanMailbox(ctx context.Context, mailboxName, mailboxPath strin
 	}
 
 	logger.Info("mailbox scan complete", "processed", processedCount, "skipped", skippedCount)
+	span.SetAttributes(
+		attribute.Int("thunderbird.messages_processed", processedCount),
+		attribute.Int("thunderbird.messages_skipped", skippedCount),
+	)
+	r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "mailbox.scan"})
 	return nil
 }
 
@@ -261,24 +299,31 @@ func (r *Reader) processMessage(
 	mailboxPath string,
 	out chan<- *api.TransactionDetails,
 ) (bool, error) {
+	ctx, span := r.observabilityScope().Start(ctx, "thunderbird.messages.process")
+	defer span.End()
+
 	messageID := msg.Header.Get("Message-Id")
 	dateStr := msg.Header.Get("Date")
 	msgKey := state.GenerateKey(mailboxPath, messageID, dateStr)
 
 	if r.state != nil && r.state.IsProcessed(ctx, msgKey) {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "messages.skipped"})
 		return false, nil
 	}
 	if r.isBeforeCheckpoint(dateStr) {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "messages.skipped"})
 		return false, nil
 	}
 
 	rule, matches := r.matchesRule(msg)
 	if !matches {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "messages.skipped"})
 		return false, nil
 	}
 
 	transaction, err := r.extractTransaction(ctx, msg, rule, msgKey)
 	if err != nil {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "messages.process", Err: err})
 		r.logger.Warn("failed to extract transaction", "error", err, "message_key", msgKey)
 		return false, nil
 	}
@@ -286,8 +331,11 @@ func (r *Reader) processMessage(
 
 	select {
 	case <-ctx.Done():
-		return false, ctx.Err()
+		err := ctx.Err()
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "messages.process", Err: err})
+		return false, err
 	case out <- transaction:
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "thunderbird", Name: "messages.process"})
 		r.logger.Debug("extracted transaction",
 			"amount", transaction.Amount,
 			"merchant", transaction.MerchantInfo,
@@ -352,10 +400,12 @@ func (r *Reader) extractTransaction(ctx context.Context, msg *mail.Message, rule
 
 func (r *Reader) recordExtractionDiagnostic(ctx context.Context, diagnostic api.ExtractionDiagnostic) {
 	if r.diagnosticSink == nil || len(diagnostic.FailureReasons) == 0 {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "diagnostics", Name: "skipped"})
 		return
 	}
 	release, ok := r.acquireDiagnosticSlot()
 	if !ok {
+		r.observabilityScope().RecordOperation(ctx, observability.Operation{Namespace: "diagnostics", Name: "skipped"})
 		r.diagnosticLogger().Warn("skipping extraction diagnostic; diagnostic recorder is saturated",
 			"reader", diagnostic.Reader, "message_id", diagnostic.MessageID)
 		return
@@ -366,7 +416,11 @@ func (r *Reader) recordExtractionDiagnostic(ctx context.Context, diagnostic api.
 		defer release()
 		diagnosticCtx, cancel := context.WithTimeout(ctx, diagnosticRecordTimeout)
 		defer cancel()
-		if err := sink.RecordExtractionDiagnostic(diagnosticCtx, diagnostic); err != nil {
+		diagnosticCtx, span := r.observabilityScope().Start(diagnosticCtx, "diagnostics.record")
+		err := sink.RecordExtractionDiagnostic(diagnosticCtx, diagnostic)
+		r.observabilityScope().RecordOperation(diagnosticCtx, observability.Operation{Namespace: "diagnostics", Name: "record", Err: err})
+		span.End()
+		if err != nil {
 			if logger == nil {
 				logger = slog.Default()
 			}

--- a/backend/pkg/writer/postgres/postgres.go
+++ b/backend/pkg/writer/postgres/postgres.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/ArionMiles/expensor/backend/internal/migration"
 	"github.com/ArionMiles/expensor/backend/migrations"
 	"github.com/ArionMiles/expensor/backend/pkg/api"
+	"github.com/ArionMiles/expensor/backend/pkg/observability"
 )
 
 // RunMigrations applies all numbered SQL migrations from the embedded migrations
@@ -52,6 +54,7 @@ type Writer struct {
 	logger        *slog.Logger
 	batchSize     int
 	flushInterval time.Duration
+	scope         *observability.Scope
 }
 
 // compile-time check: *Writer must satisfy io.Closer.
@@ -125,6 +128,7 @@ func New(cfg Config, logger *slog.Logger) (*Writer, error) {
 		logger:        logger,
 		batchSize:     cfg.BatchSize,
 		flushInterval: cfg.FlushInterval,
+		scope:         observability.NewScope(logger, "github.com/ArionMiles/expensor/backend/pkg/writer/postgres"),
 	}
 
 	// Run migrations
@@ -213,10 +217,27 @@ func (w *Writer) writeBatch(ctx context.Context, transactions []*api.Transaction
 	if len(transactions) == 0 {
 		return nil
 	}
+	ctx, span := w.observabilityScope().Start(ctx, "postgres_writer.batch_write")
+	defer span.End()
+	start := time.Now()
+	span.SetAttributes(attribute.Int("postgres_writer.batch_size", len(transactions)))
+	var writeErr error
+	defer func() {
+		w.observabilityScope().RecordDuration(ctx, observability.DurationOperation{
+			Namespace: "postgres_writer",
+			Name:      "batch_write",
+			Duration:  time.Since(start),
+			Err:       writeErr,
+			Attributes: []attribute.KeyValue{
+				attribute.Int("batch_size", len(transactions)),
+			},
+		})
+	}()
 
 	// Start a transaction
 	tx, err := w.pool.Begin(ctx)
 	if err != nil {
+		writeErr = err
 		return fmt.Errorf("beginning transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
@@ -277,12 +298,14 @@ func (w *Writer) writeBatch(ctx context.Context, transactions []*api.Transaction
 	for i := 0; i < len(transactions); i++ {
 		if err := batchResults.QueryRow().Scan(&txnIDs[i]); err != nil {
 			_ = batchResults.Close()
+			writeErr = err
 			return fmt.Errorf("inserting transaction %d: %w", i, err)
 		}
 	}
 
 	// Close batch results before executing more queries on the transaction
 	if err := batchResults.Close(); err != nil {
+		writeErr = err
 		return fmt.Errorf("closing batch results: %w", err)
 	}
 
@@ -290,27 +313,39 @@ func (w *Writer) writeBatch(ctx context.Context, transactions []*api.Transaction
 	for i, txn := range transactions {
 		if len(txn.Labels) > 0 {
 			if err := w.insertLabels(ctx, tx, txnIDs[i], txn.Labels); err != nil {
+				writeErr = err
 				return fmt.Errorf("inserting labels for transaction %s: %w", txnIDs[i], err)
 			}
 		}
 	}
 
 	if err := w.applyMerchantLabels(ctx, tx, txnIDs); err != nil {
+		writeErr = err
 		return fmt.Errorf("auto-applying merchant labels: %w", err)
 	}
 	if err := w.applyMerchantCategories(ctx, tx, txnIDs); err != nil {
+		writeErr = err
 		return fmt.Errorf("auto-applying merchant categories: %w", err)
 	}
 	if err := w.applyMutedMerchants(ctx, tx, txnIDs); err != nil {
+		writeErr = err
 		return fmt.Errorf("auto-muting transactions: %w", err)
 	}
 
 	// Commit transaction
 	if err := tx.Commit(ctx); err != nil {
+		writeErr = err
 		return fmt.Errorf("committing transaction: %w", err)
 	}
 
 	return nil
+}
+
+func (w *Writer) observabilityScope() *observability.Scope {
+	if w.scope == nil {
+		w.scope = observability.NewScope(w.logger, "github.com/ArionMiles/expensor/backend/pkg/writer/postgres")
+	}
+	return w.scope
 }
 
 func (w *Writer) normalizeWriteInput(txn *api.TransactionDetails) (string, time.Time) {

--- a/docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md
+++ b/docs/superpowers/specs/2026-05-24-backend-observability-and-code-health.md
@@ -1,7 +1,7 @@
 # Backend Observability and Code Health — Design Spec
 
 **Date:** 2026-05-24
-**Status:** Observability/store instrumentation, plugin registry cleanup, API handler decomposition/naming cleanup, and API contract coverage slices are complete on the PR branch; broader backend code-health work remains.
+**Status:** Backend observability and code-health cleanup is complete on the follow-up branch. The original PR slices landed, and the remaining observability targets, store ownership cleanup, processed-message state context cleanup, and provider-specific Gmail query cleanup have follow-up coverage.
 
 ---
 
@@ -23,9 +23,9 @@ The work has two equal outcomes:
 | API handler decomposition | Complete | Handler files are split by resource ownership; follow-up naming cleanup has also landed on the current PR branch. |
 | API handler naming cleanup | Complete | Redundant `Handle` receiver-method prefixes and `Doc` OpenAPI DTO prefixes were removed without intentional route or payload changes. |
 | API spec and contract coverage expansion | Complete for this slice | All 88 registered `/api` routes have OpenAPI `@Router` coverage and an explicit contract-test decision: 72 deterministic allowlist entries and 16 scoped exclusions for OAuth, filesystem, or live reader/runtime state. |
-| Store package ownership cleanup beyond instrumentation | Pending | Remaining work includes read-model ownership and `store.go` model/helper split. |
-| Processed-message state context cleanup | Pending | Requires a separate implementation plan. |
-| Provider-specific domain cleanup | Pending | Includes moving Gmail query construction out of `pkg/api`. |
+| Store package ownership cleanup beyond instrumentation | Complete | Model/helper files are split, read-model ownership is explicit, and `Store` keeps single-implementation repositories as concrete private fields. |
+| Processed-message state context cleanup | Complete | DB-backed processed-message state uses caller contexts. |
+| Provider-specific domain cleanup | Complete | Gmail query construction lives in the Gmail reader package; `pkg/api.Rule` stays provider-neutral. |
 
 ---
 
@@ -350,8 +350,10 @@ Run component or contract tests only for slices that touch store behavior, daemo
 7. Rename decomposed API handler methods and OpenAPI DTOs to remove redundant `Handle` and `Doc` prefixes. **Complete.**
 8. Expand OpenAPI route coverage and Schemathesis allowlist coverage in deterministic batches. **Complete for this PR slice.**
 9. Update `AGENTS.md` with backend code-health rules. **Complete.**
-10. Make processed-message state context-aware. **Pending follow-up.**
-11. Move Gmail-specific rule query construction out of `pkg/api`. **Pending follow-up.**
+10. Make processed-message state context-aware. **Complete.**
+11. Move Gmail-specific rule query construction out of `pkg/api`. **Complete.**
+12. Add observability for HTTP middleware, daemon runner, Gmail/Thunderbird readers, Postgres writer batches, diagnostics, and community sync. **Complete on follow-up branch.**
+13. Finish store facade ownership cleanup by keeping single-implementation repositories concrete and removing type-assertion bridges. **Complete on follow-up branch.**
 
 ### Current PR Branch State
 
@@ -376,9 +378,7 @@ Route and contract inventory:
 - Missing route decisions: 0.
 - Allowlist/exclusion overlaps: 0.
 
-The remaining program work is outside the API contract coverage slice: processed-message state context propagation, Gmail-specific query construction ownership, and deeper `internal/store` ownership cleanup.
-
-The exact implementation plan may split these further, but each slice should be independently testable.
+No remaining implementation gaps are tracked by this spec. Future observability work should be driven by new requirements, such as additional histograms or dashboard-specific signals, rather than this cleanup spec.
 
 ---
 


### PR DESCRIPTION
## Description

Completes the remaining backend observability and code-health cleanup from the May 24 spec. This adds low-cardinality telemetry to the remaining backend runtime boundaries and finishes the store facade ownership cleanup.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

Fixes #(issue)

## Changes Made

- Added spans and low-cardinality metrics for HTTP requests, daemon runs, Gmail/Thunderbird scans, Postgres writer batches, diagnostics recording, and community sync.
- Finished store facade cleanup by keeping single-implementation repositories as concrete private fields and removing type-assertion bridges.
- Updated the backend observability/code-health spec to mark the follow-up gaps complete.

## Testing

- [x] Unit tests pass (`task test:be`)
- [x] Linter passes (`task lint:be:prod` and `task lint:fe`)
- [ ] Manual testing completed
- [x] Added new tests (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Backend-only change. `task lint:fe` was not run separately because no frontend files changed; the commit hook skipped frontend checks as no files were applicable.