### PR TITLE
Simplify store chart and transaction queries

### DIFF
--- a/backend/internal/store/models.go
+++ b/backend/internal/store/models.go
@@ -78,13 +78,6 @@ type ChartData struct {
 	ByCategoryMonthly map[string]CategoryMonthlyEntry `json:"by_category_monthly"`
 }
 
-type chartLoadRequest struct {
-	Target *map[string]float64
-	Label  string
-	Query  string
-	Args   []any
-}
-
 // DashboardSection is one dashboard slice with a label, summary stats, and charts.
 type DashboardSection struct {
 	Label  string    `json:"label"`

--- a/backend/internal/store/read_model_repository.go
+++ b/backend/internal/store/read_model_repository.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
 )
 
 type ReadModelRepository interface {
@@ -24,6 +24,24 @@ type pgReadModelRepository struct {
 	pool    *pgxpool.Pool
 	runtime RuntimeRepository
 	now     func() time.Time
+}
+
+type chartQueryRequest struct {
+	Label string
+	Query string
+	Args  []any
+}
+
+type chartDataLoadRequest struct {
+	Monthly           chartQueryRequest
+	Daily             chartQueryRequest
+	Category          chartQueryRequest
+	Bucket            chartQueryRequest
+	Label             chartQueryRequest
+	Source            chartQueryRequest
+	SourceType        chartQueryRequest
+	Bank              chartQueryRequest
+	CategoryMonthlyFn func(context.Context) (map[string]CategoryMonthlyEntry, error)
 }
 
 func NewReadModelRepository(deps repositoryDependencies, runtime RuntimeRepository) ReadModelRepository {
@@ -112,37 +130,11 @@ func (r *pgReadModelRepository) chartDataReadModel(ctx context.Context) (*ChartD
 }
 
 func (r *pgReadModelRepository) getChartDataAt(ctx context.Context, now time.Time) (*ChartData, error) {
-	cd := &ChartData{
-		MonthlySpend:      []TimeBucket{},
-		DailySpend:        []TimeBucket{},
-		ByCategory:        make(map[string]float64),
-		ByBucket:          make(map[string]float64),
-		ByLabel:           make(map[string]float64),
-		BySource:          make(map[string]float64),
-		BySourceType:      make(map[string]float64),
-		ByBank:            make(map[string]float64),
-		ByCategoryMonthly: make(map[string]CategoryMonthlyEntry),
-	}
-
-	var mu sync.Mutex
-	var firstErr error
-
-	recordErr := func(err error) {
-		mu.Lock()
-		if firstErr == nil {
-			firstErr = err
-		}
-		mu.Unlock()
-	}
-
 	tz := r.appTimezone(ctx)
-
-	var wg sync.WaitGroup
-	wg.Add(9)
-
-	go func() {
-		defer wg.Done()
-		buckets, err := r.queryTimeBuckets(ctx, `
+	return r.loadChartData(ctx, chartDataLoadRequest{
+		Monthly: chartQueryRequest{
+			Label: "monthly spend",
+			Query: `
 			SELECT TO_CHAR(timestamp AT TIME ZONE $1, 'YYYY-MM') AS period,
 			       COALESCE(SUM(amount), 0)                     AS amount,
 			       COUNT(*)                                     AS cnt
@@ -150,19 +142,12 @@ func (r *pgReadModelRepository) getChartDataAt(ctx context.Context, now time.Tim
 			WHERE muted = false AND timestamp >= $2
 			GROUP BY period
 			ORDER BY period
-		`, tz, now.AddDate(-1, 0, 0))
-		if err != nil {
-			recordErr(fmt.Errorf("fetching monthly spend: %w", err))
-			return
-		}
-		mu.Lock()
-		cd.MonthlySpend = buckets
-		mu.Unlock()
-	}()
-
-	go func() {
-		defer wg.Done()
-		buckets, err := r.queryTimeBuckets(ctx, `
+		`,
+			Args: []any{tz, now.AddDate(-1, 0, 0)},
+		},
+		Daily: chartQueryRequest{
+			Label: "daily spend",
+			Query: `
 			SELECT TO_CHAR(timestamp AT TIME ZONE $1, 'YYYY-MM-DD') AS period,
 			       COALESCE(SUM(amount), 0)                        AS amount,
 			       COUNT(*)                                        AS cnt
@@ -170,33 +155,32 @@ func (r *pgReadModelRepository) getChartDataAt(ctx context.Context, now time.Tim
 			WHERE muted = false AND timestamp >= $2
 			GROUP BY period
 			ORDER BY period
-		`, tz, now.AddDate(0, 0, -30))
-		if err != nil {
-			recordErr(fmt.Errorf("fetching daily spend: %w", err))
-			return
-		}
-		mu.Lock()
-		cd.DailySpend = buckets
-		mu.Unlock()
-	}()
-
-	r.loadStringFloatChart(ctx, &wg, &mu, recordErr, chartLoadRequest{Target: &cd.ByCategory, Label: "category", Query: `
+		`,
+			Args: []any{tz, now.AddDate(0, 0, -30)},
+		},
+		Category: chartQueryRequest{
+			Label: "category chart data",
+			Query: `
 			SELECT COALESCE(NULLIF(category, ''), 'Uncategorized'), COALESCE(SUM(amount), 0)
 			FROM transactions
 			WHERE muted = false
 			GROUP BY COALESCE(NULLIF(category, ''), 'Uncategorized')
 			ORDER BY SUM(amount) DESC
-		`})
-
-	r.loadStringFloatChart(ctx, &wg, &mu, recordErr, chartLoadRequest{Target: &cd.ByBucket, Label: "bucket", Query: `
+		`,
+		},
+		Bucket: chartQueryRequest{
+			Label: "bucket chart data",
+			Query: `
 			SELECT COALESCE(NULLIF(bucket, ''), 'Uncategorized'), COALESCE(SUM(amount), 0)
 			FROM transactions
 			WHERE muted = false
 			GROUP BY COALESCE(NULLIF(bucket, ''), 'Uncategorized')
 			ORDER BY SUM(amount) DESC
-		`})
-
-	r.loadStringFloatChart(ctx, &wg, &mu, recordErr, chartLoadRequest{Target: &cd.ByLabel, Label: "label", Query: `
+		`,
+		},
+		Label: chartQueryRequest{
+			Label: "label chart data",
+			Query: `
 			SELECT COALESCE(tl.label, 'Uncategorized'), COALESCE(SUM(t.amount), 0)
 			FROM transactions t
 			LEFT JOIN transaction_labels tl ON tl.transaction_id = t.id
@@ -204,50 +188,42 @@ func (r *pgReadModelRepository) getChartDataAt(ctx context.Context, now time.Tim
 			GROUP BY COALESCE(tl.label, 'Uncategorized')
 			ORDER BY SUM(t.amount) DESC
 			LIMIT 20
-		`})
-
-	r.loadStringFloatChart(ctx, &wg, &mu, recordErr, chartLoadRequest{Target: &cd.BySource, Label: "source", Query: `
+		`,
+		},
+		Source: chartQueryRequest{
+			Label: "source chart data",
+			Query: `
 			SELECT COALESCE(source, ''), COALESCE(SUM(amount), 0)
 			FROM transactions
 			WHERE muted = false AND source IS NOT NULL AND source != ''
 			GROUP BY source
 			ORDER BY SUM(amount) DESC
-		`})
-
-	r.loadStringFloatChart(ctx, &wg, &mu, recordErr, chartLoadRequest{Target: &cd.BySourceType, Label: "source type", Query: `
+		`,
+		},
+		SourceType: chartQueryRequest{
+			Label: "source type chart data",
+			Query: `
 			SELECT COALESCE(source_type, ''), COALESCE(SUM(amount), 0)
 			FROM transactions
 			WHERE muted = false AND source_type IS NOT NULL AND source_type != ''
 			GROUP BY source_type
 			ORDER BY SUM(amount) DESC
-		`})
-
-	r.loadStringFloatChart(ctx, &wg, &mu, recordErr, chartLoadRequest{Target: &cd.ByBank, Label: "bank", Query: `
+		`,
+		},
+		Bank: chartQueryRequest{
+			Label: "bank chart data",
+			Query: `
 			SELECT COALESCE(bank, ''), COALESCE(SUM(amount), 0)
 			FROM transactions
 			WHERE muted = false AND bank IS NOT NULL AND bank != ''
 			GROUP BY bank
 			ORDER BY SUM(amount) DESC
-		`})
-
-	go func() {
-		defer wg.Done()
-		m, err := r.queryCategoryMonthlyAt(ctx, now)
-		if err != nil {
-			recordErr(err)
-			return
-		}
-		mu.Lock()
-		cd.ByCategoryMonthly = m
-		mu.Unlock()
-	}()
-
-	wg.Wait()
-
-	if firstErr != nil {
-		return nil, firstErr
-	}
-	return cd, nil
+		`,
+		},
+		CategoryMonthlyFn: func(ctx context.Context) (map[string]CategoryMonthlyEntry, error) {
+			return r.queryCategoryMonthlyAt(ctx, now)
+		},
+	})
 }
 
 func (r *pgReadModelRepository) dashboardDataReadModel(ctx context.Context) (*DashboardData, error) {
@@ -335,22 +311,11 @@ func (r *pgReadModelRepository) getStatsBetween(ctx context.Context, baseCurrenc
 }
 
 func (r *pgReadModelRepository) getChartDataBetween(ctx context.Context, loc *time.Location, startUTC, endUTC time.Time) (*ChartData, error) {
-	cd := &ChartData{
-		MonthlySpend:      []TimeBucket{},
-		DailySpend:        []TimeBucket{},
-		ByCategory:        make(map[string]float64),
-		ByBucket:          make(map[string]float64),
-		ByLabel:           make(map[string]float64),
-		BySource:          make(map[string]float64),
-		BySourceType:      make(map[string]float64),
-		ByBank:            make(map[string]float64),
-		ByCategoryMonthly: make(map[string]CategoryMonthlyEntry),
-	}
-
 	tz := loc.String()
-
-	var err error
-	if cd.MonthlySpend, err = r.queryTimeBuckets(ctx, `
+	return r.loadChartData(ctx, chartDataLoadRequest{
+		Monthly: chartQueryRequest{
+			Label: "range monthly spend",
+			Query: `
 		SELECT TO_CHAR(timestamp AT TIME ZONE $1, 'YYYY-MM') AS period,
 		       COALESCE(SUM(amount), 0)                    AS amount,
 		       COUNT(*)                                    AS cnt
@@ -358,11 +323,12 @@ func (r *pgReadModelRepository) getChartDataBetween(ctx context.Context, loc *ti
 		WHERE muted = false AND timestamp >= $2 AND timestamp < $3
 		GROUP BY period
 		ORDER BY period
-	`, tz, startUTC, endUTC); err != nil {
-		return nil, fmt.Errorf("fetching range monthly spend: %w", err)
-	}
-
-	if cd.DailySpend, err = r.queryTimeBuckets(ctx, `
+	`,
+			Args: []any{tz, startUTC, endUTC},
+		},
+		Daily: chartQueryRequest{
+			Label: "range daily spend",
+			Query: `
 		SELECT TO_CHAR(timestamp AT TIME ZONE $1, 'YYYY-MM-DD') AS period,
 		       COALESCE(SUM(amount), 0)                        AS amount,
 		       COUNT(*)                                        AS cnt
@@ -370,31 +336,34 @@ func (r *pgReadModelRepository) getChartDataBetween(ctx context.Context, loc *ti
 		WHERE muted = false AND timestamp >= $2 AND timestamp < $3
 		GROUP BY period
 		ORDER BY period
-	`, tz, startUTC, endUTC); err != nil {
-		return nil, fmt.Errorf("fetching range daily spend: %w", err)
-	}
-
-	if err := r.queryStringFloat(ctx, `
+	`,
+			Args: []any{tz, startUTC, endUTC},
+		},
+		Category: chartQueryRequest{
+			Label: "range category chart data",
+			Query: `
 		SELECT COALESCE(NULLIF(category, ''), 'Uncategorized'), COALESCE(SUM(amount), 0)
 		FROM transactions
 		WHERE muted = false AND timestamp >= $1 AND timestamp < $2
 		GROUP BY COALESCE(NULLIF(category, ''), 'Uncategorized')
 		ORDER BY SUM(amount) DESC
-	`, cd.ByCategory, startUTC, endUTC); err != nil {
-		return nil, fmt.Errorf("fetching range category chart data: %w", err)
-	}
-
-	if err := r.queryStringFloat(ctx, `
+	`,
+			Args: []any{startUTC, endUTC},
+		},
+		Bucket: chartQueryRequest{
+			Label: "range bucket chart data",
+			Query: `
 		SELECT COALESCE(NULLIF(bucket, ''), 'Uncategorized'), COALESCE(SUM(amount), 0)
 		FROM transactions
 		WHERE muted = false AND timestamp >= $1 AND timestamp < $2
 		GROUP BY COALESCE(NULLIF(bucket, ''), 'Uncategorized')
 		ORDER BY SUM(amount) DESC
-	`, cd.ByBucket, startUTC, endUTC); err != nil {
-		return nil, fmt.Errorf("fetching range bucket chart data: %w", err)
-	}
-
-	if err := r.queryStringFloat(ctx, `
+	`,
+			Args: []any{startUTC, endUTC},
+		},
+		Label: chartQueryRequest{
+			Label: "range label chart data",
+			Query: `
 		SELECT COALESCE(tl.label, 'Uncategorized'), COALESCE(SUM(t.amount), 0)
 		FROM transactions t
 		LEFT JOIN transaction_labels tl ON tl.transaction_id = t.id
@@ -402,48 +371,49 @@ func (r *pgReadModelRepository) getChartDataBetween(ctx context.Context, loc *ti
 		GROUP BY COALESCE(tl.label, 'Uncategorized')
 		ORDER BY SUM(t.amount) DESC
 		LIMIT 20
-	`, cd.ByLabel, startUTC, endUTC); err != nil {
-		return nil, fmt.Errorf("fetching range label chart data: %w", err)
-	}
-
-	if err := r.queryStringFloat(ctx, `
+	`,
+			Args: []any{startUTC, endUTC},
+		},
+		Source: chartQueryRequest{
+			Label: "range source chart data",
+			Query: `
 		SELECT COALESCE(source, ''), COALESCE(SUM(amount), 0)
 		FROM transactions
 		WHERE muted = false AND timestamp >= $1 AND timestamp < $2
 		  AND source IS NOT NULL AND source != ''
 		GROUP BY source
 		ORDER BY SUM(amount) DESC
-	`, cd.BySource, startUTC, endUTC); err != nil {
-		return nil, fmt.Errorf("fetching range source chart data: %w", err)
-	}
-
-	if err := r.queryStringFloat(ctx, `
+	`,
+			Args: []any{startUTC, endUTC},
+		},
+		SourceType: chartQueryRequest{
+			Label: "range source type chart data",
+			Query: `
 		SELECT COALESCE(source_type, ''), COALESCE(SUM(amount), 0)
 		FROM transactions
 		WHERE muted = false AND timestamp >= $1 AND timestamp < $2
 		  AND source_type IS NOT NULL AND source_type != ''
 		GROUP BY source_type
 		ORDER BY SUM(amount) DESC
-	`, cd.BySourceType, startUTC, endUTC); err != nil {
-		return nil, fmt.Errorf("fetching range source type chart data: %w", err)
-	}
-
-	if err := r.queryStringFloat(ctx, `
+	`,
+			Args: []any{startUTC, endUTC},
+		},
+		Bank: chartQueryRequest{
+			Label: "range bank chart data",
+			Query: `
 		SELECT COALESCE(bank, ''), COALESCE(SUM(amount), 0)
 		FROM transactions
 		WHERE muted = false AND timestamp >= $1 AND timestamp < $2
 		  AND bank IS NOT NULL AND bank != ''
 		GROUP BY bank
 		ORDER BY SUM(amount) DESC
-	`, cd.ByBank, startUTC, endUTC); err != nil {
-		return nil, fmt.Errorf("fetching range bank chart data: %w", err)
-	}
-
-	if cd.ByCategoryMonthly, err = r.queryCategoryMonthlyBetween(ctx, loc, startUTC, endUTC); err != nil {
-		return nil, err
-	}
-
-	return cd, nil
+	`,
+			Args: []any{startUTC, endUTC},
+		},
+		CategoryMonthlyFn: func(ctx context.Context) (map[string]CategoryMonthlyEntry, error) {
+			return r.queryCategoryMonthlyBetween(ctx, loc, startUTC, endUTC)
+		},
+	})
 }
 
 // queryCategoryMonthly returns per-category spend totals for the current and prior calendar month.
@@ -672,24 +642,71 @@ func (r *pgReadModelRepository) queryStringFloat(ctx context.Context, q string, 
 	return rows.Err()
 }
 
-func (r *pgReadModelRepository) loadStringFloatChart(
-	ctx context.Context,
-	wg *sync.WaitGroup,
-	mu *sync.Mutex,
-	recordErr func(error),
-	request chartLoadRequest,
-) {
-	go func() {
-		defer wg.Done()
-		values := make(map[string]float64)
-		if err := r.queryStringFloat(ctx, request.Query, values, request.Args...); err != nil {
-			recordErr(fmt.Errorf("fetching %s chart data: %w", request.Label, err))
-			return
+func (r *pgReadModelRepository) loadChartData(ctx context.Context, request chartDataLoadRequest) (*ChartData, error) {
+	cd := newChartData()
+	g, groupCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		buckets, err := r.queryTimeBuckets(groupCtx, request.Monthly.Query, request.Monthly.Args...)
+		if err != nil {
+			return fmt.Errorf("fetching %s: %w", request.Monthly.Label, err)
 		}
-		mu.Lock()
-		*request.Target = values
-		mu.Unlock()
-	}()
+		cd.MonthlySpend = buckets
+		return nil
+	})
+
+	g.Go(func() error {
+		buckets, err := r.queryTimeBuckets(groupCtx, request.Daily.Query, request.Daily.Args...)
+		if err != nil {
+			return fmt.Errorf("fetching %s: %w", request.Daily.Label, err)
+		}
+		cd.DailySpend = buckets
+		return nil
+	})
+
+	loadStringFloat := func(request chartQueryRequest, dest map[string]float64) {
+		g.Go(func() error {
+			if err := r.queryStringFloat(groupCtx, request.Query, dest, request.Args...); err != nil {
+				return fmt.Errorf("fetching %s: %w", request.Label, err)
+			}
+			return nil
+		})
+	}
+
+	loadStringFloat(request.Category, cd.ByCategory)
+	loadStringFloat(request.Bucket, cd.ByBucket)
+	loadStringFloat(request.Label, cd.ByLabel)
+	loadStringFloat(request.Source, cd.BySource)
+	loadStringFloat(request.SourceType, cd.BySourceType)
+	loadStringFloat(request.Bank, cd.ByBank)
+
+	g.Go(func() error {
+		m, err := request.CategoryMonthlyFn(groupCtx)
+		if err != nil {
+			return err
+		}
+		cd.ByCategoryMonthly = m
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return cd, nil
+}
+
+func newChartData() *ChartData {
+	return &ChartData{
+		MonthlySpend:      []TimeBucket{},
+		DailySpend:        []TimeBucket{},
+		ByCategory:        make(map[string]float64),
+		ByBucket:          make(map[string]float64),
+		ByLabel:           make(map[string]float64),
+		BySource:          make(map[string]float64),
+		BySourceType:      make(map[string]float64),
+		ByBank:            make(map[string]float64),
+		ByCategoryMonthly: make(map[string]CategoryMonthlyEntry),
+	}
 }
 
 // initAppConfig creates the app_config table and seeds operational defaults.

--- a/backend/internal/store/store_test.go
+++ b/backend/internal/store/store_test.go
@@ -1150,6 +1150,46 @@ func TestSearchTransactions(t *testing.T) {
 	}
 }
 
+func TestSearchTransactions_HonorsAscendingSort(t *testing.T) {
+	ts := newTestStore(t)
+	defer ts.cleanup()
+	ctx := context.Background()
+
+	for _, p := range []store.InsertParams{
+		{
+			MessageID:    "srch-sort-new",
+			Amount:       200,
+			Currency:     "INR",
+			MerchantInfo: "Coffee New",
+			Category:     "Food",
+			Timestamp:    time.Date(2026, time.March, 2, 9, 0, 0, 0, time.UTC),
+		},
+		{
+			MessageID:    "srch-sort-old",
+			Amount:       100,
+			Currency:     "INR",
+			MerchantInfo: "Coffee Old",
+			Category:     "Food",
+			Timestamp:    time.Date(2026, time.March, 1, 9, 0, 0, 0, time.UTC),
+		},
+	} {
+		if _, err := ts.InsertForTest(ctx, p); err != nil {
+			t.Fatalf("InsertForTest: %v", err)
+		}
+	}
+
+	txns, _, err := ts.SearchTransactions(ctx, "Coffee", store.ListFilter{PageSize: 10, SortDir: "asc"})
+	if err != nil {
+		t.Fatalf("SearchTransactions: %v", err)
+	}
+	if len(txns) != 2 {
+		t.Fatalf("expected 2 search results, got %d", len(txns))
+	}
+	if txns[0].MessageID != "srch-sort-old" || txns[1].MessageID != "srch-sort-new" {
+		t.Fatalf("expected ascending search order, got %q then %q", txns[0].MessageID, txns[1].MessageID)
+	}
+}
+
 func TestSearchTransactions_EmptyQuery(t *testing.T) {
 	ts := newTestStore(t)
 	defer ts.cleanup()

--- a/backend/internal/store/transactions_repository.go
+++ b/backend/internal/store/transactions_repository.go
@@ -37,6 +37,13 @@ type pgTransactionsRepository struct {
 	pool *pgxpool.Pool
 }
 
+type transactionQueryRequest struct {
+	filter     ListFilter
+	search     string
+	countError string
+	dataError  string
+}
+
 func NewTransactionsRepository(deps repositoryDependencies) TransactionsRepository {
 	return newPGTransactionsRepository(deps)
 }
@@ -52,31 +59,37 @@ func (r *pgTransactionsRepository) ListTransactions(ctx context.Context, f ListF
 }
 
 func (r *pgTransactionsRepository) listTransactionsQuery(ctx context.Context, f ListFilter) ([]Transaction, TransactionListResult, error) {
-	if f.Page < 1 {
-		f.Page = 1
-	}
-	if f.PageSize < 1 {
-		f.PageSize = 20
-	}
+	return r.queryTransactions(ctx, transactionQueryRequest{
+		filter:     f,
+		countError: "counting transactions",
+		dataError:  "listing transactions",
+	})
+}
+
+func (r *pgTransactionsRepository) queryTransactions(
+	ctx context.Context,
+	request transactionQueryRequest,
+) ([]Transaction, TransactionListResult, error) {
+	f := normalizeTransactionListFilter(request.filter)
+	query := strings.TrimSpace(request.search)
 
 	where, args := buildListWhere(f)
+	if query != "" {
+		searchCond := buildSearchCondition(query, &args)
+		where = combineWhere(searchCond, where)
+	}
+
 	offset := (f.Page - 1) * f.PageSize
 	join := joinLabel(f.Label)
 
 	result, err := r.queryTransactionTotals(ctx, join, where, args)
 	if err != nil {
-		return nil, TransactionListResult{}, fmt.Errorf("counting transactions: %w", err)
+		return nil, TransactionListResult{}, fmt.Errorf("%s: %w", request.countError, err)
 	}
 
 	args = append(args, f.PageSize, offset)
 	limitArg := len(args) - 1
 	offsetArg := len(args)
-
-	orderClause := "t.timestamp DESC"
-	if strings.ToLower(f.SortDir) == "asc" {
-		orderClause = "t.timestamp ASC"
-	}
-
 	dataSQL := fmt.Sprintf(`
 		SELECT DISTINCT t.id, t.message_id, t.amount, t.currency,
 		       t.original_amount, t.original_currency, t.exchange_rate,
@@ -87,11 +100,11 @@ func (r *pgTransactionsRepository) listTransactionsQuery(ctx context.Context, f 
 		FROM transactions t%s%s
 		ORDER BY %s
 		LIMIT $%d OFFSET $%d
-	`, join, where, orderClause, limitArg, offsetArg)
+	`, join, where, transactionOrderClause(f), limitArg, offsetArg)
 
 	rows, err := r.pool.Query(ctx, dataSQL, args...)
 	if err != nil {
-		return nil, TransactionListResult{}, fmt.Errorf("listing transactions: %w", err)
+		return nil, TransactionListResult{}, fmt.Errorf("%s: %w", request.dataError, err)
 	}
 	defer rows.Close()
 
@@ -105,6 +118,23 @@ func (r *pgTransactionsRepository) listTransactionsQuery(ctx context.Context, f 
 	}
 
 	return txns, result, nil
+}
+
+func normalizeTransactionListFilter(f ListFilter) ListFilter {
+	if f.Page < 1 {
+		f.Page = 1
+	}
+	if f.PageSize < 1 {
+		f.PageSize = 20
+	}
+	return f
+}
+
+func transactionOrderClause(f ListFilter) string {
+	if strings.ToLower(f.SortDir) == "asc" {
+		return "t.timestamp ASC"
+	}
+	return "t.timestamp DESC"
 }
 
 func (r *pgTransactionsRepository) GetTransaction(ctx context.Context, id string) (*Transaction, error) {
@@ -265,59 +295,16 @@ func (r *pgTransactionsRepository) searchTransactionsQuery(
 	query string,
 	f ListFilter,
 ) ([]Transaction, TransactionListResult, error) {
-	if f.Page < 1 {
-		f.Page = 1
-	}
-	if f.PageSize < 1 {
-		f.PageSize = 20
-	}
-
 	query = strings.TrimSpace(query)
 	if query == "" {
 		return r.listTransactionsQuery(ctx, f)
 	}
-
-	where, args := buildListWhere(f)
-	searchCond := buildSearchCondition(query, &args)
-	fullWhere := combineWhere(searchCond, where)
-	offset := (f.Page - 1) * f.PageSize
-
-	join := joinLabel(f.Label)
-	result, err := r.queryTransactionTotals(ctx, join, fullWhere, args)
-	if err != nil {
-		return nil, TransactionListResult{}, fmt.Errorf("counting search results: %w", err)
-	}
-
-	args = append(args, f.PageSize, offset)
-	limitArg := len(args) - 1
-	offsetArg := len(args)
-
-	dataSQL := fmt.Sprintf(`
-		SELECT DISTINCT t.id, t.message_id, t.amount, t.currency,
-		       t.original_amount, t.original_currency, t.exchange_rate,
-		       t.timestamp, t.merchant_info,
-		       COALESCE(t.category, ''), COALESCE(t.bucket, ''),
-		       t.source, COALESCE(t.source_type, ''), COALESCE(t.source_label, ''), COALESCE(t.bank, ''),
-		       COALESCE(t.description, ''), t.muted, t.muted_by_merchant, COALESCE(t.mute_reason,''), t.created_at, t.updated_at
-		FROM transactions t%s%s
-		ORDER BY t.timestamp DESC
-		LIMIT $%d OFFSET $%d
-	`, join, fullWhere, limitArg, offsetArg)
-
-	rows, err := r.pool.Query(ctx, dataSQL, args...)
-	if err != nil {
-		return nil, TransactionListResult{}, fmt.Errorf("searching transactions: %w", err)
-	}
-	defer rows.Close()
-
-	txns, err := scanTransactions(rows)
-	if err != nil {
-		return nil, TransactionListResult{}, err
-	}
-	if err := r.loadLabels(ctx, txns); err != nil {
-		return nil, TransactionListResult{}, err
-	}
-	return txns, result, nil
+	return r.queryTransactions(ctx, transactionQueryRequest{
+		filter:     f,
+		search:     query,
+		countError: "counting search results",
+		dataError:  "searching transactions",
+	})
 }
 
 func (r *pgTransactionsRepository) GetFacets(ctx context.Context) (*Facets, error) {


### PR DESCRIPTION
## Description

Refactors store read paths to reduce duplicated query orchestration and remove hand-rolled chart-data concurrency.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

N/A

## Changes Made

- Replaced manual chart-data `WaitGroup`/mutex/error capture with a shared `errgroup.WithContext` loader used by both all-time and bounded dashboard chart paths.
- Consolidated transaction list/search query assembly so pagination, filtering, ordering, totals, scanning, and label loading share one code path.
- Added regression coverage for `SearchTransactions` honoring ascending timestamp sort.

## Testing

- [x] Unit tests pass (`task test:be`)
- [x] Linter passes (`task lint:be:prod` and `task lint:fe`)
- [ ] Manual testing completed
- [x] Added new tests (if applicable)

Additional verification run:

- `go test -run TestSearchTransactions_HonorsAscendingSort -count=1 ./internal/store`
- `go test -run 'Test(GetChartData|GetDashboardData)' -count=1 ./internal/store`
- `go test -count=1 ./internal/store`
- `task test:be`
- `task lint:be:prod`

`task lint:fe` was not run because this PR touches backend Go files only; pre-commit skipped frontend checks because no frontend files changed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Pre-commit also ran Go format, lint, tests, and audit successfully during commit creation.
