### PR TITLE
Refine API store capability boundaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN npm run build
 # --platform=$BUILDPLATFORM keeps the Go toolchain running natively on the build
 # host. Cross-compilation is handled purely via GOOS/GOARCH env vars below —
 # no QEMU required even when targeting linux/arm64.
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine AS backend-builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS backend-builder
 
 # Install build tooling needed by the Go toolchain.
 # This layer is cached as long as the base image doesn't change.

--- a/api/openapi/expensor.openapi.yaml
+++ b/api/openapi/expensor.openapi.yaml
@@ -301,7 +301,7 @@ definitions:
   api.ErrorResponse:
     properties:
       error:
-        example: database not connected
+        example: internal server error
         type: string
     type: object
   api.ExtractionDiagnosticResponse:

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -94,6 +94,25 @@ type daemonManager struct {
 	lastError string
 }
 
+type categorySnapshotStore interface {
+	LoadCategorySnapshot(ctx context.Context) (api.CategoryResolver, error)
+}
+
+type communitySyncStore interface {
+	SeedMCCCodes(ctx context.Context, entries []store.MCCEntry) error
+	SeedMerchantCategories(ctx context.Context, entries []store.MerchantCategoryEntry) (int, error)
+	SetSyncStatus(ctx context.Context, status store.SyncStatus) error
+}
+
+type daemonRuntimeStore interface {
+	GetReaderSecret(ctx context.Context, reader string) ([]byte, bool, error)
+	GetReaderToken(ctx context.Context, reader string) ([]byte, bool, error)
+	SetReaderToken(ctx context.Context, reader string, token []byte) error
+	GetReaderConfig(ctx context.Context, reader string) (json.RawMessage, bool, error)
+	IsMessageProcessed(ctx context.Context, key string) (bool, error)
+	MarkMessageProcessed(ctx context.Context, key string, at time.Time) error
+}
+
 func (m *daemonManager) setRunning(t time.Time) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -126,18 +145,20 @@ func (m *daemonManager) Status() httpapi.DaemonStatus {
 // It exposes start and rescan as plain methods so they can be passed as func(string)
 // values without adding closure complexity to main.
 type daemonCoordinator struct {
-	mu           sync.Mutex
-	ctx          context.Context
-	cancelFn     context.CancelFunc // cancels the current daemon run; nil when idle
-	activeReader string             // reader name currently running or last launched
-	registry     *plugins.Registry
-	cfg          config.Config
-	systemRules  []api.Rule
-	resolver     api.CategoryResolver
-	st           httpapi.Storer
-	diagnostics  api.DiagnosticSink
-	dm           *daemonManager
-	logger       *slog.Logger
+	mu            sync.Mutex
+	ctx           context.Context
+	cancelFn      context.CancelFunc // cancels the current daemon run; nil when idle
+	activeReader  string             // reader name currently running or last launched
+	registry      *plugins.Registry
+	cfg           config.Config
+	systemRules   []api.Rule
+	resolver      api.CategoryResolver
+	st            httpapi.Storer
+	runtimeStore  daemonRuntimeStore
+	resolverStore categorySnapshotStore
+	diagnostics   api.DiagnosticSink
+	dm            *daemonManager
+	logger        *slog.Logger
 }
 
 // launch builds runtime config and merged rules then spawns runDaemon in a goroutine.
@@ -170,7 +191,7 @@ func (c *daemonCoordinator) launch(readerName string, forceRescan bool) {
 	merged := pkgrules.MergeRules(c.systemRules, loadUserRules(c.ctx, c.st, c.logger))
 	go func() {
 		defer cancel()
-		runDaemon(runCtx, c.registry, readerName, runtimeCfg, merged, c.resolver, c.diagnostics, c.st, c.dm, c.logger, forceRescan)
+		runDaemon(runCtx, c.registry, readerName, runtimeCfg, merged, c.resolver, c.diagnostics, c.runtimeStore, c.dm, c.logger, forceRescan)
 	}()
 }
 
@@ -294,7 +315,7 @@ func (c *daemonCoordinator) restart(readerName string) {
 // refreshResolver reloads the CategoryResolver from the DB snapshot and, if
 // the daemon is running, restarts it so the new mappings take effect immediately.
 func (c *daemonCoordinator) refreshResolver(ctx context.Context) {
-	resolver, err := c.st.LoadCategorySnapshot(ctx)
+	resolver, err := c.resolverStore.LoadCategorySnapshot(ctx)
 	if err != nil {
 		c.logger.Warn("failed to reload category snapshot after sync", "error", err)
 		return
@@ -408,7 +429,7 @@ func run() int {
 	dc := &daemonCoordinator{
 		ctx: ctx, registry: registry, cfg: cfg,
 		systemRules: content.rules, resolver: resolver,
-		st: st, diagnostics: instrumentedStore, dm: dm, logger: logger,
+		st: st, runtimeStore: instrumentedStore, resolverStore: instrumentedStore, diagnostics: instrumentedStore, dm: dm, logger: logger,
 	}
 
 	// Auto-start daemon if a previous reader selection was persisted.
@@ -417,7 +438,7 @@ func run() int {
 		dc.start(savedReader)
 	}
 
-	syncFn := startCommunitySync(ctx, pgStore, st, dc, logger)
+	syncFn := startCommunitySync(ctx, pgStore, instrumentedStore, dc, logger)
 	handlers := httpapi.NewHandlers(httpapi.HandlersConfig{
 		Registry:           registry,
 		Store:              st,
@@ -455,7 +476,7 @@ func runDaemon( //nolint:revive // all parameters are required; splitting furthe
 	rules []api.Rule,
 	resolver api.CategoryResolver,
 	diagnosticSink api.DiagnosticSink,
-	runtimeStore httpapi.Storer,
+	runtimeStore daemonRuntimeStore,
 	dm *daemonManager,
 	logger *slog.Logger,
 	forceRescan bool,
@@ -779,7 +800,7 @@ func loadAppConfig() (config.Config, error) {
 // startCommunitySync seeds the default community URL (if absent), launches the
 // initial sync, and starts the background ticker goroutine. It returns a syncFn
 // that triggers a manual sync + resolver refresh.
-func startCommunitySync(ctx context.Context, pgStore *store.Store, st httpapi.Storer, dc *daemonCoordinator, logger *slog.Logger) func() {
+func startCommunitySync(ctx context.Context, pgStore *store.Store, st communitySyncStore, dc *daemonCoordinator, logger *slog.Logger) func() {
 	syncInterval := 24 * time.Hour
 	if v := os.Getenv("EXPENSOR_CONTENT_SYNC_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
@@ -863,7 +884,7 @@ func applyScanOverrides(cfg config.Config, st httpapi.Storer) config.Config {
 // syncCommunityContent fetches mcc.json and categories.json from the community URL,
 // upserts them into the DB, and updates the sync status in app_config.
 // Non-fatal: errors are logged and stored as sync status; caller continues.
-func syncCommunityContent(ctx context.Context, st httpapi.Storer, baseURL string, logger *slog.Logger) {
+func syncCommunityContent(ctx context.Context, st communitySyncStore, baseURL string, logger *slog.Logger) {
 	if baseURL == "" {
 		return
 	}
@@ -932,7 +953,7 @@ func syncCommunityContent(ctx context.Context, st httpapi.Storer, baseURL string
 	logger.Info("community sync complete", "entries_updated", updated)
 }
 
-func recordSyncError(ctx context.Context, st httpapi.Storer, syncErr error, logger *slog.Logger) {
+func recordSyncError(ctx context.Context, st communitySyncStore, syncErr error, logger *slog.Logger) {
 	logger.Warn("community sync failed", "error", syncErr)
 	errStr := syncErr.Error()
 	status := store.SyncStatus{Error: &errStr}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArionMiles/expensor/backend
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/emersion/go-mbox v1.0.4

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -47,7 +47,15 @@ type DaemonStatusProvider interface {
 // Handlers holds all dependencies for HTTP endpoint handlers.
 type Handlers struct {
 	registry           *plugins.Registry
-	store              Storer
+	settingsStore      settingsStore
+	analyticsStore     analyticsStore
+	transactionStore   transactionStore
+	muteStore          muteStore
+	taxonomyStore      taxonomyStore
+	readerRuntimeStore readerRuntimeStore
+	ruleStore          ruleStore
+	syncStore          syncStore
+	diagnosticStore    diagnosticStore
 	daemon             DaemonStatusProvider
 	version            string // set at build time via ldflags
 	baseURL            string // e.g. "http://localhost:8080"
@@ -89,7 +97,6 @@ type HandlersConfig struct {
 }
 
 // NewHandlers creates a Handlers instance.
-// Pass nil Store when no database is configured; transaction endpoints will return 503.
 // Pass nil StartFn to disable the daemon start endpoint.
 func NewHandlers(cfg HandlersConfig) *Handlers {
 	if cfg.FrontendURL == "" {
@@ -103,7 +110,15 @@ func NewHandlers(cfg HandlersConfig) *Handlers {
 	}
 	return &Handlers{
 		registry:           cfg.Registry,
-		store:              cfg.Store,
+		settingsStore:      cfg.Store,
+		analyticsStore:     cfg.Store,
+		transactionStore:   cfg.Store,
+		muteStore:          cfg.Store,
+		taxonomyStore:      cfg.Store,
+		readerRuntimeStore: cfg.Store,
+		ruleStore:          cfg.Store,
+		syncStore:          cfg.Store,
+		diagnosticStore:    cfg.Store,
 		daemon:             cfg.Daemon,
 		version:            cfg.Version,
 		baseURL:            strings.TrimRight(cfg.BaseURL, "/"),
@@ -159,12 +174,14 @@ func (h *Handlers) Status(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := statusResponse{Daemon: ds}
 
-	if h.store != nil {
-		currency := h.currentBaseCurrency(r.Context())
-		if stats, err := h.store.GetStats(r.Context(), currency); err == nil {
-			resp.Stats = stats
-		}
+	currency := h.currentBaseCurrency(r.Context())
+	stats, err := h.analyticsStore.GetStats(r.Context(), currency)
+	if err != nil {
+		h.logger.Error("get status stats", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to fetch stats")
+		return
 	}
+	resp.Stats = stats
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/backend/internal/api/handlers_config.go
+++ b/backend/internal/api/handlers_config.go
@@ -36,10 +36,6 @@ func (h *Handlers) ListBanks(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/base-currency [get]
 func (h *Handlers) GetBaseCurrency(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	writeJSON(w, http.StatusOK, map[string]string{"base_currency": h.currentBaseCurrency(r.Context())})
 }
 
@@ -57,10 +53,6 @@ func (h *Handlers) GetBaseCurrency(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/base-currency [put]
 func (h *Handlers) SetBaseCurrency(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body struct {
 		BaseCurrency string `json:"base_currency"`
 	}
@@ -79,7 +71,7 @@ func (h *Handlers) SetBaseCurrency(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := h.store.SetAppConfig(r.Context(), "base_currency", currency); err != nil {
+	if err := h.settingsStore.SetAppConfig(r.Context(), "base_currency", currency); err != nil {
 		h.logger.Error("set base currency", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update base currency")
 		return
@@ -95,12 +87,8 @@ func (h *Handlers) SetBaseCurrency(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/scan-interval [get]
 func (h *Handlers) GetScanInterval(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	val := strconv.Itoa(h.scanInterval)
-	if dbVal, err := h.store.GetAppConfig(r.Context(), "scan_interval"); err == nil && dbVal != "" {
+	if dbVal, err := h.settingsStore.GetAppConfig(r.Context(), "scan_interval"); err == nil && dbVal != "" {
 		val = dbVal
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"scan_interval": val})
@@ -119,29 +107,16 @@ func (h *Handlers) GetScanInterval(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse
 // @Failure 503 {object} ErrorResponse
 // @Router /config/scan-interval [put]
-func (h *Handlers) SetScanInterval(w http.ResponseWriter, r *http.Request) { //nolint:dupl // same shape as SetLookbackDays; different key and bounds
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	var body struct {
-		ScanInterval string `json:"scan_interval"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ScanInterval == "" {
-		writeError(w, http.StatusUnprocessableEntity, "body must be {\"scan_interval\": \"<seconds>\"}")
-		return
-	}
-	n, err := strconv.Atoi(body.ScanInterval)
-	if err != nil || n < 10 || n > 3600 {
-		writeError(w, http.StatusBadRequest, "scan_interval must be an integer between 10 and 3600 seconds")
-		return
-	}
-	if err := h.store.SetAppConfig(r.Context(), "scan_interval", body.ScanInterval); err != nil {
-		h.logger.Error("set scan interval", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to update scan interval")
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"scan_interval": body.ScanInterval})
+func (h *Handlers) SetScanInterval(w http.ResponseWriter, r *http.Request) {
+	h.setNumericAppConfig(w, r, numericConfigSpec{
+		key:         "scan_interval",
+		min:         10,
+		max:         3600,
+		bodyMessage: "body must be {\"scan_interval\": \"<seconds>\"}",
+		rangeMsg:    "scan_interval must be an integer between 10 and 3600 seconds",
+		logMessage:  "set scan interval",
+		errorMsg:    "failed to update scan interval",
+	})
 }
 
 // GetLookbackDays handles GET /api/config/lookback-days.
@@ -152,12 +127,8 @@ func (h *Handlers) SetScanInterval(w http.ResponseWriter, r *http.Request) { //n
 // @Failure 503 {object} ErrorResponse
 // @Router /config/lookback-days [get]
 func (h *Handlers) GetLookbackDays(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	val := strconv.Itoa(h.lookbackDays)
-	if dbVal, err := h.store.GetAppConfig(r.Context(), "lookback_days"); err == nil && dbVal != "" {
+	if dbVal, err := h.settingsStore.GetAppConfig(r.Context(), "lookback_days"); err == nil && dbVal != "" {
 		val = dbVal
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"lookback_days": val})
@@ -176,29 +147,46 @@ func (h *Handlers) GetLookbackDays(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse
 // @Failure 503 {object} ErrorResponse
 // @Router /config/lookback-days [put]
-func (h *Handlers) SetLookbackDays(w http.ResponseWriter, r *http.Request) { //nolint:dupl // same shape as SetScanInterval; different key and bounds
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
+func (h *Handlers) SetLookbackDays(w http.ResponseWriter, r *http.Request) {
+	h.setNumericAppConfig(w, r, numericConfigSpec{
+		key:         "lookback_days",
+		min:         1,
+		max:         3650,
+		bodyMessage: "body must be {\"lookback_days\": \"<days>\"}",
+		rangeMsg:    "lookback_days must be an integer between 1 and 3650",
+		logMessage:  "set lookback days",
+		errorMsg:    "failed to update lookback days",
+	})
+}
+
+type numericConfigSpec struct {
+	key         string
+	min         int
+	max         int
+	bodyMessage string
+	rangeMsg    string
+	logMessage  string
+	errorMsg    string
+}
+
+func (h *Handlers) setNumericAppConfig(w http.ResponseWriter, r *http.Request, spec numericConfigSpec) {
+	var body map[string]string
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body[spec.key] == "" {
+		writeError(w, http.StatusUnprocessableEntity, spec.bodyMessage)
 		return
 	}
-	var body struct {
-		LookbackDays string `json:"lookback_days"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.LookbackDays == "" {
-		writeError(w, http.StatusUnprocessableEntity, "body must be {\"lookback_days\": \"<days>\"}")
+	value := body[spec.key]
+	n, err := strconv.Atoi(value)
+	if err != nil || n < spec.min || n > spec.max {
+		writeError(w, http.StatusBadRequest, spec.rangeMsg)
 		return
 	}
-	n, err := strconv.Atoi(body.LookbackDays)
-	if err != nil || n < 1 || n > 3650 {
-		writeError(w, http.StatusBadRequest, "lookback_days must be an integer between 1 and 3650")
+	if err := h.settingsStore.SetAppConfig(r.Context(), spec.key, value); err != nil {
+		h.logger.Error(spec.logMessage, "error", err)
+		writeError(w, http.StatusInternalServerError, spec.errorMsg)
 		return
 	}
-	if err := h.store.SetAppConfig(r.Context(), "lookback_days", body.LookbackDays); err != nil {
-		h.logger.Error("set lookback days", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to update lookback days")
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"lookback_days": body.LookbackDays})
+	writeJSON(w, http.StatusOK, map[string]string{spec.key: value})
 }
 
 // validTimeFormats is the set of accepted time_format values.
@@ -217,12 +205,8 @@ var validTimeFormats = map[string]bool{
 // @Failure 503 {object} ErrorResponse
 // @Router /config/timezone [get]
 func (h *Handlers) GetTimezone(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	tz := ""
-	if dbVal, err := h.store.GetAppConfig(r.Context(), "app.timezone"); err == nil && dbVal != "" {
+	if dbVal, err := h.settingsStore.GetAppConfig(r.Context(), "app.timezone"); err == nil && dbVal != "" {
 		tz = dbVal
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"timezone": tz})
@@ -242,10 +226,6 @@ func (h *Handlers) GetTimezone(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/timezone [put]
 func (h *Handlers) SetTimezone(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body struct {
 		Timezone string `json:"timezone"`
 	}
@@ -258,7 +238,7 @@ func (h *Handlers) SetTimezone(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid IANA timezone string")
 		return
 	}
-	if err := h.store.SetAppConfig(r.Context(), "app.timezone", tz); err != nil {
+	if err := h.settingsStore.SetAppConfig(r.Context(), "app.timezone", tz); err != nil {
 		h.logger.Error("set timezone", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update timezone")
 		return
@@ -274,12 +254,8 @@ func (h *Handlers) SetTimezone(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/time-format [get]
 func (h *Handlers) GetTimeFormat(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	tf := "HH:mm"
-	if dbVal, err := h.store.GetAppConfig(r.Context(), "app.time_format"); err == nil && dbVal != "" {
+	if dbVal, err := h.settingsStore.GetAppConfig(r.Context(), "app.time_format"); err == nil && dbVal != "" {
 		tf = dbVal
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"time_format": tf})
@@ -299,10 +275,6 @@ func (h *Handlers) GetTimeFormat(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/time-format [put]
 func (h *Handlers) SetTimeFormat(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body struct {
 		TimeFormat string `json:"time_format"`
 	}
@@ -315,7 +287,7 @@ func (h *Handlers) SetTimeFormat(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid time_format; accepted: HH:mm, HH:mm:ss, h:mm a, h:mm:ss a")
 		return
 	}
-	if err := h.store.SetAppConfig(r.Context(), "app.time_format", tf); err != nil {
+	if err := h.settingsStore.SetAppConfig(r.Context(), "app.time_format", tf); err != nil {
 		h.logger.Error("set time format", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update time format")
 		return
@@ -334,7 +306,7 @@ func (h *Handlers) missingSetupPreferences(ctx context.Context) []string {
 	}
 	missing := make([]string, 0, len(required))
 	for _, pref := range required {
-		value, err := h.store.GetAppConfig(ctx, pref.key)
+		value, err := h.settingsStore.GetAppConfig(ctx, pref.key)
 		if err != nil || strings.TrimSpace(value) == "" {
 			missing = append(missing, pref.field)
 		}
@@ -350,10 +322,6 @@ func (h *Handlers) missingSetupPreferences(ctx context.Context) []string {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/setup-status [get]
 func (h *Handlers) GetSetupStatus(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	missing := h.missingSetupPreferences(r.Context())
 	writeJSON(w, http.StatusOK, map[string]any{
 		"required": len(missing) > 0,
@@ -371,12 +339,8 @@ func (h *Handlers) GetSetupStatus(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/readers/{name}/checkpoint [get]
 func (h *Handlers) GetReaderCheckpoint(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
-	val, err := h.store.GetAppConfig(r.Context(), "reader."+name+".last_scan_at")
+	val, err := h.settingsStore.GetAppConfig(r.Context(), "reader."+name+".last_scan_at")
 	if err != nil || val == "" {
 		writeJSON(w, http.StatusOK, map[string]any{"last_scan_at": nil})
 		return
@@ -396,12 +360,8 @@ func (h *Handlers) GetReaderCheckpoint(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/readers/{name}/checkpoint [delete]
 func (h *Handlers) ClearReaderCheckpoint(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
-	if err := h.store.SetAppConfig(r.Context(), "reader."+name+".last_scan_at", ""); err != nil {
+	if err := h.settingsStore.SetAppConfig(r.Context(), "reader."+name+".last_scan_at", ""); err != nil {
 		h.logger.Error("clear reader checkpoint", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to clear checkpoint")
 		return
@@ -423,11 +383,9 @@ func (h *Handlers) resolveTimezone(ctx context.Context, requested string) string
 			return requested
 		}
 	}
-	if h.store != nil {
-		if configured, err := h.store.GetAppConfig(ctx, "app.timezone"); err == nil && configured != "" {
-			if _, err := time.LoadLocation(configured); err == nil {
-				return configured
-			}
+	if configured, err := h.settingsStore.GetAppConfig(ctx, "app.timezone"); err == nil && configured != "" {
+		if _, err := time.LoadLocation(configured); err == nil {
+			return configured
 		}
 	}
 	return fallback

--- a/backend/internal/api/handlers_diagnostics.go
+++ b/backend/internal/api/handlers_diagnostics.go
@@ -23,11 +23,6 @@ import (
 // @Failure 503 {object} ErrorResponse
 // @Router /extraction-diagnostics [get]
 func (h *Handlers) ListExtractionDiagnostics(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	status := r.URL.Query().Get("status")
 	if status == "" {
 		status = store.DiagnosticStatusOpen
@@ -47,7 +42,7 @@ func (h *Handlers) ListExtractionDiagnostics(w http.ResponseWriter, r *http.Requ
 		filter.Limit = limit
 	}
 
-	rows, err := h.store.ListExtractionDiagnostics(r.Context(), filter)
+	rows, err := h.diagnosticStore.ListExtractionDiagnostics(r.Context(), filter)
 	if err != nil {
 		h.logger.Error("list extraction diagnostics", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list extraction diagnostics")
@@ -71,18 +66,13 @@ func (h *Handlers) ListExtractionDiagnostics(w http.ResponseWriter, r *http.Requ
 // @Failure 503 {object} ErrorResponse
 // @Router /extraction-diagnostics/{id} [get]
 func (h *Handlers) GetExtractionDiagnostic(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	id := r.PathValue("id")
 	if _, err := uuid.Parse(id); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid extraction diagnostic id")
 		return
 	}
 
-	row, err := h.store.GetExtractionDiagnostic(r.Context(), id)
+	row, err := h.diagnosticStore.GetExtractionDiagnostic(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "extraction diagnostic not found")
@@ -111,11 +101,6 @@ func (h *Handlers) GetExtractionDiagnostic(w http.ResponseWriter, r *http.Reques
 // @Failure 503 {object} ErrorResponse
 // @Router /extraction-diagnostics/{id}/status [put]
 func (h *Handlers) UpdateExtractionDiagnosticStatus(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	id := r.PathValue("id")
 	if _, err := uuid.Parse(id); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid extraction diagnostic id")
@@ -132,7 +117,7 @@ func (h *Handlers) UpdateExtractionDiagnosticStatus(w http.ResponseWriter, r *ht
 		return
 	}
 
-	row, err := h.store.UpdateExtractionDiagnosticStatus(r.Context(), id, body.Status)
+	row, err := h.diagnosticStore.UpdateExtractionDiagnosticStatus(r.Context(), id, body.Status)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "extraction diagnostic not found")

--- a/backend/internal/api/handlers_readers.go
+++ b/backend/internal/api/handlers_readers.go
@@ -137,11 +137,7 @@ func (h *Handlers) UploadCredentials(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	if err := h.store.SetReaderSecret(r.Context(), name, body); err != nil {
+	if err := h.readerRuntimeStore.SetReaderSecret(r.Context(), name, body); err != nil {
 		h.logger.Error("failed to save credentials", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to save credentials")
 		return
@@ -167,11 +163,7 @@ func (h *Handlers) CredentialsStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.store == nil {
-		writeJSON(w, http.StatusOK, map[string]bool{"exists": false})
-		return
-	}
-	_, exists, err := h.store.GetReaderSecret(r.Context(), name)
+	_, exists, err := h.readerRuntimeStore.GetReaderSecret(r.Context(), name)
 	if err != nil {
 		h.logger.Error("failed to load credentials status", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to load credentials status")
@@ -219,12 +211,8 @@ func (h *Handlers) AuthStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	h.logger.Debug("reading credentials from store", "reader", name)
-	secretJSON, ok, err := h.store.GetReaderSecret(r.Context(), name)
+	secretJSON, ok, err := h.readerRuntimeStore.GetReaderSecret(r.Context(), name)
 	if err != nil {
 		h.logger.Error("failed to load credentials", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to load credentials")
@@ -285,10 +273,7 @@ func (h *Handlers) exchangeAndSaveToken(ctx context.Context, name, code, redirec
 		return fmt.Errorf("%w: %w", errReaderNotRegistered, err)
 	}
 
-	if h.store == nil {
-		return errors.New("database not connected")
-	}
-	secretJSON, ok, err := h.store.GetReaderSecret(ctx, name)
+	secretJSON, ok, err := h.readerRuntimeStore.GetReaderSecret(ctx, name)
 	if err != nil {
 		return fmt.Errorf("failed to load credentials: %w", err)
 	}
@@ -310,7 +295,7 @@ func (h *Handlers) exchangeAndSaveToken(ctx context.Context, name, code, redirec
 	if err != nil {
 		return fmt.Errorf("failed to marshal token: %w", err)
 	}
-	if err := h.store.SetReaderToken(ctx, name, tokenJSON); err != nil {
+	if err := h.readerRuntimeStore.SetReaderToken(ctx, name, tokenJSON); err != nil {
 		return fmt.Errorf("failed to save token: %w", err)
 	}
 	h.restartReaderDaemonAfterAuth(name)
@@ -489,14 +474,7 @@ func (h *Handlers) AuthStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.store == nil {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"authenticated": false,
-			"auth_state":    authStateReauthorizationRequired,
-		})
-		return
-	}
-	tokenJSON, ok, err := h.store.GetReaderToken(r.Context(), name)
+	tokenJSON, ok, err := h.readerRuntimeStore.GetReaderToken(r.Context(), name)
 	if err != nil {
 		h.logger.Error("failed to load token", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to load token")
@@ -538,7 +516,7 @@ func (h *Handlers) resolveOAuthTokenState(ctx context.Context, name string, scop
 		return oauthTokenState{authState: authStateReauthorizationRequired, expiry: expiry}, nil
 	}
 
-	secretJSON, ok, err := h.store.GetReaderSecret(ctx, name)
+	secretJSON, ok, err := h.readerRuntimeStore.GetReaderSecret(ctx, name)
 	if err != nil {
 		return oauthTokenState{authState: authStateRefreshPending, expiry: expiry}, fmt.Errorf("loading credentials for token refresh: %w", err)
 	}
@@ -561,7 +539,7 @@ func (h *Handlers) resolveOAuthTokenState(ctx context.Context, name string, scop
 	if err != nil {
 		return oauthTokenState{authState: authStateRefreshPending, expiry: expiry}, fmt.Errorf("marshaling refreshed token: %w", err)
 	}
-	if err := h.store.SetReaderToken(ctx, name, refreshedJSON); err != nil {
+	if err := h.readerRuntimeStore.SetReaderToken(ctx, name, refreshedJSON); err != nil {
 		return oauthTokenState{authState: authStateRefreshPending, expiry: expiry}, fmt.Errorf("saving refreshed token: %w", err)
 	}
 	return oauthTokenState{authenticated: true, authState: authStateConnected, expiry: tokenExpiry(*refreshed)}, nil
@@ -584,10 +562,7 @@ func (h *Handlers) resolveReaderAuthStatus(ctx context.Context, name string, met
 	if meta.Auth.Type != plugins.AuthTypeOAuth {
 		return true, authStateConnected
 	}
-	if h.store == nil {
-		return false, authStateReauthorizationRequired
-	}
-	tokenJSON, ok, err := h.store.GetReaderToken(ctx, name)
+	tokenJSON, ok, err := h.readerRuntimeStore.GetReaderToken(ctx, name)
 	if err != nil || !ok {
 		return false, authStateReauthorizationRequired
 	}
@@ -616,23 +591,19 @@ func (h *Handlers) DisconnectReader(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	activeReader, err := h.store.GetActiveReader(r.Context())
+	activeReader, err := h.readerRuntimeStore.GetActiveReader(r.Context())
 	if err != nil {
 		h.logger.Error("failed to read active reader before disconnect", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to disconnect reader")
 		return
 	}
-	if err := h.store.DeleteReaderRuntime(r.Context(), name); err != nil {
+	if err := h.readerRuntimeStore.DeleteReaderRuntime(r.Context(), name); err != nil {
 		h.logger.Error("failed to disconnect reader", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to disconnect reader")
 		return
 	}
 	if activeReader == name {
-		if err := h.store.SetAppConfig(r.Context(), "active_reader", ""); err != nil {
+		if err := h.readerRuntimeStore.SetActiveReader(r.Context(), ""); err != nil {
 			h.logger.Error("failed to clear active reader", "reader", name, "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to disconnect reader")
 			return
@@ -663,11 +634,7 @@ func (h *Handlers) RevokeToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	if _, ok, err := h.store.GetReaderToken(r.Context(), name); err != nil {
+	if _, ok, err := h.readerRuntimeStore.GetReaderToken(r.Context(), name); err != nil {
 		h.logger.Error("failed to load token", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to remove token")
 		return
@@ -675,7 +642,7 @@ func (h *Handlers) RevokeToken(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "no token found")
 		return
 	}
-	if err := h.store.DeleteReaderToken(r.Context(), name); err != nil {
+	if err := h.readerRuntimeStore.DeleteReaderToken(r.Context(), name); err != nil {
 		h.logger.Error("failed to remove token", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to remove token")
 		return
@@ -703,11 +670,7 @@ func (h *Handlers) GetReaderConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.store == nil {
-		writeJSON(w, http.StatusOK, map[string]any{})
-		return
-	}
-	data, ok, err := h.store.GetReaderConfig(r.Context(), name)
+	data, ok, err := h.readerRuntimeStore.GetReaderConfig(r.Context(), name)
 	if err != nil {
 		h.logger.Error("failed to read config", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to read config")
@@ -758,11 +721,7 @@ func (h *Handlers) SaveReaderConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	if err := h.store.SetReaderConfig(r.Context(), name, json.RawMessage(body)); err != nil {
+	if err := h.readerRuntimeStore.SetReaderConfig(r.Context(), name, json.RawMessage(body)); err != nil {
 		h.logger.Error("failed to save config", "reader", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to save config")
 		return
@@ -802,10 +761,13 @@ func (h *Handlers) ReaderStatus(w http.ResponseWriter, r *http.Request) {
 	st := readerStatus{AuthType: meta.Auth.Type}
 
 	if meta.Auth.RequiresCredentialsUpload {
-		if h.store != nil {
-			_, ok, err := h.store.GetReaderSecret(r.Context(), name)
-			st.CredentialsUploaded = err == nil && ok
+		_, ok, err := h.readerRuntimeStore.GetReaderSecret(r.Context(), name)
+		if err != nil {
+			h.logger.Error("failed to load credentials status", "reader", name, "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to load credentials status")
+			return
 		}
+		st.CredentialsUploaded = ok
 	} else {
 		st.CredentialsUploaded = true
 	}
@@ -814,9 +776,14 @@ func (h *Handlers) ReaderStatus(w http.ResponseWriter, r *http.Request) {
 
 	if len(meta.ConfigSchema) == 0 {
 		st.ConfigPresent = true
-	} else if h.store != nil {
-		_, ok, err := h.store.GetReaderConfig(r.Context(), name)
-		st.ConfigPresent = err == nil && ok
+	} else {
+		_, ok, err := h.readerRuntimeStore.GetReaderConfig(r.Context(), name)
+		if err != nil {
+			h.logger.Error("failed to load reader config status", "reader", name, "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to load reader config status")
+			return
+		}
+		st.ConfigPresent = ok
 	}
 
 	st.Ready = st.CredentialsUploaded && st.Authenticated && st.ConfigPresent

--- a/backend/internal/api/handlers_rules.go
+++ b/backend/internal/api/handlers_rules.go
@@ -250,11 +250,7 @@ func validateRuleRow(row store.RuleRow) error {
 // @Failure 503 {object} ErrorResponse
 // @Router /rules [get]
 func (h *Handlers) ListRules(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	rules, err := h.store.ListRules(r.Context())
+	rules, err := h.ruleStore.ListRules(r.Context())
 	if err != nil {
 		h.logger.Error("list rules", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list rules")
@@ -277,10 +273,6 @@ func (h *Handlers) ListRules(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /rules [post]
 func (h *Handlers) CreateRule(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body ruleHTTPJSON
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusUnprocessableEntity, "invalid JSON body")
@@ -291,7 +283,7 @@ func (h *Handlers) CreateRule(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
-	created, err := h.store.CreateRule(r.Context(), row)
+	created, err := h.ruleStore.CreateRule(r.Context(), row)
 	if err != nil {
 		if errors.Is(err, store.ErrRuleNameConflict) {
 			writeError(w, http.StatusConflict, "rule name already exists")
@@ -307,11 +299,11 @@ func (h *Handlers) CreateRule(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handlers) clearActiveReaderCheckpointForNewRule(ctx context.Context) {
 	reader, err := h.readActiveReader(ctx)
-	if err != nil || strings.TrimSpace(reader) == "" || h.store == nil {
+	if err != nil || strings.TrimSpace(reader) == "" {
 		return
 	}
 	reader = strings.TrimSpace(reader)
-	if err := h.store.SetAppConfig(ctx, "reader."+reader+".last_scan_at", ""); err != nil {
+	if err := h.settingsStore.SetAppConfig(ctx, "reader."+reader+".last_scan_at", ""); err != nil {
 		h.logger.Warn("failed to clear checkpoint after rule creation", "reader", reader, "error", err)
 		return
 	}
@@ -321,10 +313,7 @@ func (h *Handlers) clearActiveReaderCheckpointForNewRule(ctx context.Context) {
 }
 
 func (h *Handlers) readActiveReader(ctx context.Context) (string, error) {
-	if h.store == nil {
-		return "", nil
-	}
-	return h.store.GetActiveReader(ctx)
+	return h.readerRuntimeStore.GetActiveReader(ctx)
 }
 
 // UpdateRule handles PUT /api/rules/{id}.
@@ -345,10 +334,6 @@ func (h *Handlers) readActiveReader(ctx context.Context) (string, error) {
 // @Failure 503 {object} ErrorResponse
 // @Router /rules/{id} [put]
 func (h *Handlers) UpdateRule(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	id, ok := uuidPathValue(w, r, "id", "rule")
 	if !ok {
 		return
@@ -363,7 +348,7 @@ func (h *Handlers) UpdateRule(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
-	updated, err := h.store.UpdateRule(r.Context(), id, row)
+	updated, err := h.ruleStore.UpdateRule(r.Context(), id, row)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "rule not found")
@@ -395,15 +380,11 @@ func (h *Handlers) UpdateRule(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /rules/{id} [delete]
 func (h *Handlers) DeleteRule(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	id, ok := uuidPathValue(w, r, "id", "rule")
 	if !ok {
 		return
 	}
-	existing, err := h.store.GetRule(r.Context(), id)
+	existing, err := h.ruleStore.GetRule(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "rule not found")
@@ -416,7 +397,7 @@ func (h *Handlers) DeleteRule(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, "predefined rules cannot be deleted")
 		return
 	}
-	if err := h.store.DeleteRule(r.Context(), id); err != nil {
+	if err := h.ruleStore.DeleteRule(r.Context(), id); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "rule not found")
 			return
@@ -440,11 +421,7 @@ func (h *Handlers) DeleteRule(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /rules/export [get]
 func (h *Handlers) ExportRules(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	all, err := h.store.ListRules(r.Context())
+	all, err := h.ruleStore.ListRules(r.Context())
 	if err != nil {
 		h.logger.Error("export rules", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to fetch rules")
@@ -477,10 +454,6 @@ func (h *Handlers) ExportRules(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /rules/import [post]
 func (h *Handlers) ImportRules(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	r.Body = http.MaxBytesReader(w, r.Body, 5<<20)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -496,7 +469,7 @@ func (h *Handlers) ImportRules(w http.ResponseWriter, r *http.Request) {
 	for _, rule := range doc.Rules {
 		rows = append(rows, ruleToRow(rule))
 	}
-	if err := h.store.ImportUserRules(r.Context(), rows); err != nil {
+	if err := h.ruleStore.ImportUserRules(r.Context(), rows); err != nil {
 		h.logger.Error("import rules", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to import rules")
 		return

--- a/backend/internal/api/handlers_stats.go
+++ b/backend/internal/api/handlers_stats.go
@@ -16,11 +16,7 @@ import (
 // @Failure 503 {object} ErrorResponse
 // @Router /stats/charts [get]
 func (h *Handlers) GetChartData(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	cd, err := h.store.GetChartData(r.Context())
+	cd, err := h.analyticsStore.GetChartData(r.Context())
 	if err != nil {
 		h.logger.Error("get chart data", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to fetch chart data")
@@ -38,12 +34,7 @@ func (h *Handlers) GetChartData(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /stats/dashboard [get]
 func (h *Handlers) GetDashboardData(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
-	data, err := h.store.GetDashboardData(r.Context())
+	data, err := h.analyticsStore.GetDashboardData(r.Context())
 	if err != nil {
 		h.logger.Error("get dashboard data", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to fetch dashboard data")
@@ -67,18 +58,13 @@ func (h *Handlers) GetDashboardData(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /stats/heatmap [get]
 func (h *Handlers) GetHeatmap(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	from, to, err := parseHeatmapRange(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	data, err := h.store.GetSpendingHeatmap(r.Context(), from, to)
+	data, err := h.analyticsStore.GetSpendingHeatmap(r.Context(), from, to)
 	if err != nil {
 		h.logger.Error("get heatmap", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to fetch heatmap data")
@@ -99,18 +85,13 @@ func (h *Handlers) GetHeatmap(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /stats/heatmap/annual [get]
 func (h *Handlers) GetAnnualHeatmap(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	yearStr := r.URL.Query().Get("year")
 	year, err := strconv.Atoi(yearStr)
 	if err != nil || year < 1 {
 		year = time.Now().Year()
 	}
 
-	buckets, err := h.store.GetAnnualSpend(r.Context(), year)
+	buckets, err := h.analyticsStore.GetAnnualSpend(r.Context(), year)
 	if err != nil {
 		h.logger.Error("get annual heatmap", "error", err, "year", year)
 		writeError(w, http.StatusInternalServerError, "failed to fetch annual heatmap data")

--- a/backend/internal/api/handlers_sync.go
+++ b/backend/internal/api/handlers_sync.go
@@ -30,11 +30,7 @@ func (h *Handlers) TriggerSync(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/sync/status [get]
 func (h *Handlers) GetSyncStatus(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	status, err := h.store.GetSyncStatus(r.Context())
+	status, err := h.syncStore.GetSyncStatus(r.Context())
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/backend/internal/api/handlers_taxonomy.go
+++ b/backend/internal/api/handlers_taxonomy.go
@@ -21,11 +21,7 @@ import (
 // @Failure 503 {object} ErrorResponse
 // @Router /config/labels [get]
 func (h *Handlers) ListLabels(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	labels, err := h.store.ListLabels(r.Context())
+	labels, err := h.taxonomyStore.ListLabels(r.Context())
 	if err != nil {
 		h.logger.Error("list labels", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list labels")
@@ -47,10 +43,6 @@ func (h *Handlers) ListLabels(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/labels [post]
 func (h *Handlers) CreateLabel(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body struct {
 		Name  string `json:"name"`
 		Color string `json:"color"`
@@ -62,7 +54,7 @@ func (h *Handlers) CreateLabel(w http.ResponseWriter, r *http.Request) {
 	if body.Color == "" {
 		body.Color = "#6366f1"
 	}
-	if err := h.store.CreateLabel(r.Context(), body.Name, body.Color); err != nil {
+	if err := h.taxonomyStore.CreateLabel(r.Context(), body.Name, body.Color); err != nil {
 		h.logger.Error("create label", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to create label")
 		return
@@ -85,10 +77,6 @@ func (h *Handlers) CreateLabel(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/labels/{name} [put]
 func (h *Handlers) UpdateLabel(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
 	var body struct {
 		Color string `json:"color"`
@@ -97,7 +85,7 @@ func (h *Handlers) UpdateLabel(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnprocessableEntity, "body must be {\"color\": \"<hex>\"}")
 		return
 	}
-	if err := h.store.UpdateLabel(r.Context(), name, body.Color); err != nil {
+	if err := h.taxonomyStore.UpdateLabel(r.Context(), name, body.Color); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "label not found")
 			return
@@ -119,16 +107,12 @@ func (h *Handlers) UpdateLabel(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/labels/{name} [delete]
 func (h *Handlers) DeleteLabel(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
 	removeFromTransactions, ok := taxonomyCleanupFlag(w, r)
 	if !ok {
 		return
 	}
-	if err := h.store.DeleteLabel(r.Context(), name, removeFromTransactions); err != nil {
+	if err := h.taxonomyStore.DeleteLabel(r.Context(), name, removeFromTransactions); err != nil {
 		h.logger.Error("delete label", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to delete label")
 		return
@@ -150,10 +134,6 @@ func (h *Handlers) DeleteLabel(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/labels/{name}/apply [post]
 func (h *Handlers) ApplyLabel(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
 	var body struct {
 		MerchantPattern string `json:"merchant_pattern"`
@@ -162,7 +142,7 @@ func (h *Handlers) ApplyLabel(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnprocessableEntity, "body must be {\"merchant_pattern\": \"<pattern>\"}")
 		return
 	}
-	affected, err := h.store.ApplyLabelByMerchant(r.Context(), name, body.MerchantPattern)
+	affected, err := h.taxonomyStore.ApplyLabelByMerchant(r.Context(), name, body.MerchantPattern)
 	if err != nil {
 		h.logger.Error("apply label", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to apply label")
@@ -185,10 +165,6 @@ func (h *Handlers) ApplyLabel(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/labels/{name}/merchant [delete]
 func (h *Handlers) RemoveLabelByMerchant(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
 	var body struct {
 		MerchantPattern string `json:"merchant_pattern"`
@@ -197,7 +173,7 @@ func (h *Handlers) RemoveLabelByMerchant(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusUnprocessableEntity, "body must be {\"merchant_pattern\": \"<pattern>\"}")
 		return
 	}
-	removed, err := h.store.RemoveLabelByMerchant(r.Context(), name, body.MerchantPattern)
+	removed, err := h.taxonomyStore.RemoveLabelByMerchant(r.Context(), name, body.MerchantPattern)
 	if err != nil {
 		h.logger.Error("remove label by merchant", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to remove label")
@@ -221,11 +197,6 @@ func (h *Handlers) RemoveLabelByMerchant(w http.ResponseWriter, r *http.Request)
 // @Failure 503 {object} ErrorResponse
 // @Router /stats/labels/monthly [get]
 func (h *Handlers) GetLabelMonthlySpend(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	dimension := strings.TrimSpace(r.URL.Query().Get("dimension"))
 	if dimension == "" {
 		dimension = "labels"
@@ -237,7 +208,7 @@ func (h *Handlers) GetLabelMonthlySpend(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	data, err := h.store.GetMonthlyBreakdownSpend(r.Context(), dimension, 12)
+	data, err := h.analyticsStore.GetMonthlyBreakdownSpend(r.Context(), dimension, 12)
 	if err != nil {
 		h.logger.Error("get monthly breakdown spend", "dimension", dimension, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to fetch monthly breakdown spend")
@@ -256,11 +227,7 @@ func (h *Handlers) GetLabelMonthlySpend(w http.ResponseWriter, r *http.Request) 
 // @Failure 503 {object} ErrorResponse
 // @Router /config/labels/mappings [get]
 func (h *Handlers) GetLabelMappings(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	mappings, err := h.store.GetLabelMappings(r.Context())
+	mappings, err := h.taxonomyStore.GetLabelMappings(r.Context())
 	if err != nil {
 		h.logger.Error("get label mappings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to get label mappings")
@@ -279,17 +246,13 @@ func (h *Handlers) GetLabelMappings(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/labels/export [get]
 func (h *Handlers) ExportLabels(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	labels, err := h.store.ListLabels(r.Context())
+	labels, err := h.taxonomyStore.ListLabels(r.Context())
 	if err != nil {
 		h.logger.Error("export labels", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list labels")
 		return
 	}
-	mappings, err := h.store.GetLabelMappings(r.Context())
+	mappings, err := h.taxonomyStore.GetLabelMappings(r.Context())
 	if err != nil {
 		h.logger.Error("export label mappings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list label mappings")
@@ -329,9 +292,9 @@ func (h *Handlers) ExportCategories(w http.ResponseWriter, r *http.Request) {
 		singular: "category",
 		plural:   "categories",
 		filename: "expensor-categories.json",
-		list:     func(ctx context.Context) ([]store.Category, error) { return h.store.ListCategories(ctx) },
+		list:     func(ctx context.Context) ([]store.Category, error) { return h.taxonomyStore.ListCategories(ctx) },
 		getMappings: func(ctx context.Context) (map[string][]string, error) {
-			return h.store.GetCategoryMappings(ctx)
+			return h.taxonomyStore.GetCategoryMappings(ctx)
 		},
 		nameOf: func(item store.Category) string { return item.Name },
 	})
@@ -346,11 +309,7 @@ func (h *Handlers) ExportCategories(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/categories/mappings [get]
 func (h *Handlers) GetCategoryMappings(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	mappings, err := h.store.GetCategoryMappings(r.Context())
+	mappings, err := h.taxonomyStore.GetCategoryMappings(r.Context())
 	if err != nil {
 		h.logger.Error("get category mappings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to get category mappings")
@@ -368,11 +327,7 @@ func (h *Handlers) GetCategoryMappings(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/categories [get]
 func (h *Handlers) ListCategories(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	cats, err := h.store.ListCategories(r.Context())
+	cats, err := h.taxonomyStore.ListCategories(r.Context())
 	if err != nil {
 		h.logger.Error("list categories", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list categories")
@@ -393,10 +348,6 @@ func (h *Handlers) ListCategories(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/categories [post]
 func (h *Handlers) CreateCategory(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
@@ -405,7 +356,7 @@ func (h *Handlers) CreateCategory(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnprocessableEntity, "body must include \"name\"")
 		return
 	}
-	if err := h.store.CreateCategory(r.Context(), body.Name, body.Description); err != nil {
+	if err := h.taxonomyStore.CreateCategory(r.Context(), body.Name, body.Description); err != nil {
 		h.logger.Error("create category", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to create category")
 		return
@@ -423,16 +374,12 @@ func (h *Handlers) CreateCategory(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/categories/{name} [delete]
 func (h *Handlers) DeleteCategory(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
 	removeFromTransactions, ok := taxonomyCleanupFlag(w, r)
 	if !ok {
 		return
 	}
-	if err := h.store.DeleteCategory(r.Context(), name, removeFromTransactions); err != nil {
+	if err := h.taxonomyStore.DeleteCategory(r.Context(), name, removeFromTransactions); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "category not found")
 			return
@@ -458,7 +405,7 @@ func (h *Handlers) DeleteCategory(w http.ResponseWriter, r *http.Request) {
 // @Router /config/categories/{name}/apply [post]
 func (h *Handlers) ApplyCategoryByMerchant(w http.ResponseWriter, r *http.Request) {
 	h.handleApplyTaxonomyMerchant(w, r, "category", func(ctx context.Context, category, pattern string) (int64, error) {
-		return h.store.ApplyCategoryByMerchant(ctx, category, pattern)
+		return h.taxonomyStore.ApplyCategoryByMerchant(ctx, category, pattern)
 	})
 }
 
@@ -476,7 +423,7 @@ func (h *Handlers) ApplyCategoryByMerchant(w http.ResponseWriter, r *http.Reques
 // @Router /config/categories/{name}/merchant [delete]
 func (h *Handlers) RemoveCategoryByMerchant(w http.ResponseWriter, r *http.Request) {
 	h.handleRemoveTaxonomyMerchant(w, r, "category", func(ctx context.Context, category, pattern string) (int64, error) {
-		return h.store.RemoveCategoryByMerchant(ctx, category, pattern)
+		return h.taxonomyStore.RemoveCategoryByMerchant(ctx, category, pattern)
 	})
 }
 
@@ -489,11 +436,7 @@ func (h *Handlers) RemoveCategoryByMerchant(w http.ResponseWriter, r *http.Reque
 // @Failure 503 {object} ErrorResponse
 // @Router /config/buckets [get]
 func (h *Handlers) ListBuckets(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	bkts, err := h.store.ListBuckets(r.Context())
+	bkts, err := h.taxonomyStore.ListBuckets(r.Context())
 	if err != nil {
 		h.logger.Error("list buckets", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list buckets")
@@ -514,10 +457,6 @@ func (h *Handlers) ListBuckets(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/buckets [post]
 func (h *Handlers) CreateBucket(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
@@ -526,7 +465,7 @@ func (h *Handlers) CreateBucket(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnprocessableEntity, "body must include \"name\"")
 		return
 	}
-	if err := h.store.CreateBucket(r.Context(), body.Name, body.Description); err != nil {
+	if err := h.taxonomyStore.CreateBucket(r.Context(), body.Name, body.Description); err != nil {
 		h.logger.Error("create bucket", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to create bucket")
 		return
@@ -544,16 +483,12 @@ func (h *Handlers) CreateBucket(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/buckets/{name} [delete]
 func (h *Handlers) DeleteBucket(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
 	removeFromTransactions, ok := taxonomyCleanupFlag(w, r)
 	if !ok {
 		return
 	}
-	if err := h.store.DeleteBucket(r.Context(), name, removeFromTransactions); err != nil {
+	if err := h.taxonomyStore.DeleteBucket(r.Context(), name, removeFromTransactions); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "bucket not found")
 			return
@@ -579,9 +514,9 @@ func (h *Handlers) ExportBuckets(w http.ResponseWriter, r *http.Request) {
 		singular: "bucket",
 		plural:   "buckets",
 		filename: "expensor-buckets.json",
-		list:     func(ctx context.Context) ([]store.Bucket, error) { return h.store.ListBuckets(ctx) },
+		list:     func(ctx context.Context) ([]store.Bucket, error) { return h.taxonomyStore.ListBuckets(ctx) },
 		getMappings: func(ctx context.Context) (map[string][]string, error) {
-			return h.store.GetBucketMappings(ctx)
+			return h.taxonomyStore.GetBucketMappings(ctx)
 		},
 		nameOf: func(item store.Bucket) string { return item.Name },
 	})
@@ -596,11 +531,7 @@ func (h *Handlers) ExportBuckets(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /config/buckets/mappings [get]
 func (h *Handlers) GetBucketMappings(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	mappings, err := h.store.GetBucketMappings(r.Context())
+	mappings, err := h.taxonomyStore.GetBucketMappings(r.Context())
 	if err != nil {
 		h.logger.Error("get bucket mappings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to get bucket mappings")
@@ -623,7 +554,7 @@ func (h *Handlers) GetBucketMappings(w http.ResponseWriter, r *http.Request) {
 // @Router /config/buckets/{name}/apply [post]
 func (h *Handlers) ApplyBucketByMerchant(w http.ResponseWriter, r *http.Request) {
 	h.handleApplyTaxonomyMerchant(w, r, "bucket", func(ctx context.Context, bucket, pattern string) (int64, error) {
-		return h.store.ApplyBucketByMerchant(ctx, bucket, pattern)
+		return h.taxonomyStore.ApplyBucketByMerchant(ctx, bucket, pattern)
 	})
 }
 
@@ -641,7 +572,7 @@ func (h *Handlers) ApplyBucketByMerchant(w http.ResponseWriter, r *http.Request)
 // @Router /config/buckets/{name}/merchant [delete]
 func (h *Handlers) RemoveBucketByMerchant(w http.ResponseWriter, r *http.Request) {
 	h.handleRemoveTaxonomyMerchant(w, r, "bucket", func(ctx context.Context, bucket, pattern string) (int64, error) {
-		return h.store.RemoveBucketByMerchant(ctx, bucket, pattern)
+		return h.taxonomyStore.RemoveBucketByMerchant(ctx, bucket, pattern)
 	})
 }
 
@@ -680,10 +611,6 @@ func handleExportNamedTaxonomy[T any](
 	config taxonomyExportConfig[T],
 ) {
 	h := config.handlers
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	items, err := config.list(r.Context())
 	if err != nil {
 		h.logger.Error("export taxonomy", "kind", config.singular, "error", err)
@@ -747,10 +674,6 @@ func (h *Handlers) handleTaxonomyMerchant(
 	r *http.Request,
 	action taxonomyMerchantAction,
 ) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	name := r.PathValue("name")
 	var body struct {
 		MerchantPattern string `json:"merchant_pattern"`
@@ -783,11 +706,6 @@ func (h *Handlers) handleTaxonomyMerchant(
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id}/labels [post]
 func (h *Handlers) AddLabels(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	id, ok := uuidPathValue(w, r, "id", "transaction")
 	if !ok {
 		return
@@ -800,7 +718,7 @@ func (h *Handlers) AddLabels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.store.AddLabels(r.Context(), id, body.Labels); err != nil {
+	if err := h.transactionStore.AddLabels(r.Context(), id, body.Labels); err != nil {
 		h.logger.Error("add labels", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to add labels")
 		return
@@ -822,18 +740,13 @@ func (h *Handlers) AddLabels(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id}/labels/{label} [delete]
 func (h *Handlers) RemoveLabel(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	id, ok := uuidPathValue(w, r, "id", "transaction")
 	if !ok {
 		return
 	}
 	label := r.PathValue("label")
 
-	if err := h.store.RemoveLabel(r.Context(), id, label); err != nil {
+	if err := h.transactionStore.RemoveLabel(r.Context(), id, label); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "label not found on transaction")
 			return

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -51,7 +51,6 @@ type mockStore struct {
 	getResult             *store.Transaction
 	getErr                error
 	updateErr             error
-	addLabelErr           error
 	addLabelsErr          error
 	removeLblErr          error
 	searchResult          []store.Transaction
@@ -64,7 +63,6 @@ type mockStore struct {
 	dashboardErr          error
 	appConfig             map[string]string
 	setConfigErr          error
-	processedMessages     map[string]time.Time
 	activeReader          string
 	readerSecrets         map[string][]byte
 	readerTokens          map[string][]byte
@@ -119,14 +117,6 @@ func (m *mockStore) ListTransactions(
 
 func (m *mockStore) GetTransaction(_ context.Context, _ string) (*store.Transaction, error) {
 	return m.getResult, m.getErr
-}
-
-func (m *mockStore) UpdateDescription(_ context.Context, _, _ string) error {
-	return m.updateErr
-}
-
-func (m *mockStore) AddLabel(_ context.Context, _, _ string) error {
-	return m.addLabelErr
 }
 
 func (m *mockStore) AddLabels(_ context.Context, _ string, _ []string) error {
@@ -221,19 +211,6 @@ func (m *mockStore) SetAppConfig(_ context.Context, key, value string) error {
 	if key == "active_reader" {
 		m.activeReader = value
 	}
-	return nil
-}
-
-func (m *mockStore) IsMessageProcessed(_ context.Context, key string) (bool, error) {
-	_, ok := m.processedMessages[key]
-	return ok, nil
-}
-
-func (m *mockStore) MarkMessageProcessed(_ context.Context, key string, at time.Time) error {
-	if m.processedMessages == nil {
-		m.processedMessages = make(map[string]time.Time)
-	}
-	m.processedMessages[key] = at
 	return nil
 }
 
@@ -478,10 +455,6 @@ func (m *mockStore) DeleteRule(_ context.Context, _ string) error {
 	return m.ruleErr
 }
 
-func (m *mockStore) SeedPredefinedRules(_ context.Context, _ []store.RuleRow) error {
-	return nil
-}
-
 func (m *mockStore) ImportUserRules(_ context.Context, rows []store.RuleRow) error {
 	m.importedRules = rows
 	return m.importErr
@@ -499,7 +472,6 @@ func (m *mockStore) GetMutedMerchantsWithCount(_ context.Context) ([]store.Muted
 	return []store.MutedMerchantWithCount{}, nil
 }
 func (m *mockStore) DeleteMutedMerchant(_ context.Context, _ string) error          { return nil }
-func (m *mockStore) UnmuteByPattern(_ context.Context, _ string) error              { return nil }
 func (m *mockStore) DeleteMutedMerchantAndUnmute(_ context.Context, _ string) error { return nil }
 func (m *mockStore) CategorizeMerchant(_ context.Context, _, _, _ string) (int, error) {
 	if m.categorizeMerchantN != 0 {
@@ -667,22 +639,6 @@ func TestHealth(t *testing.T) {
 
 // --- status ---
 
-func TestStatus_NilStore(t *testing.T) {
-	dm := &mockDaemon{status: DaemonStatus{Running: true}}
-	h := newTestHandlers(t, nil, dm)
-	rr := get(h.Status, "/api/status")
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	var resp map[string]any
-	decodeJSON(t, rr.Body.String(), &resp)
-	daemon := resp["daemon"].(map[string]any)
-	if daemon["running"] != true {
-		t.Errorf("expected daemon.running=true")
-	}
-}
-
 func TestStatus_WithStats(t *testing.T) {
 	st := &mockStore{stats: &store.Stats{TotalCount: 42, TotalBase: 99999, BaseCurrency: "INR"}}
 	h := newTestHandlers(t, st, &mockDaemon{})
@@ -696,6 +652,21 @@ func TestStatus_WithStats(t *testing.T) {
 	stats := resp["stats"].(map[string]any)
 	if stats["total_count"] != float64(42) {
 		t.Errorf("expected stats.total_count=42, got %v", stats["total_count"])
+	}
+}
+
+func TestStatus_StatsError(t *testing.T) {
+	st := &mockStore{statsErr: errors.New("stats failed")}
+	h := newTestHandlers(t, st, &mockDaemon{})
+	rr := get(h.Status, "/api/status")
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rr.Code)
+	}
+	var resp map[string]string
+	decodeJSON(t, rr.Body.String(), &resp)
+	if resp["error"] != "failed to fetch stats" {
+		t.Errorf("expected failed to fetch stats error, got %q", resp["error"])
 	}
 }
 
@@ -775,7 +746,7 @@ func TestListWriters(t *testing.T) {
 // --- credentials status ---
 
 func TestCredentialsStatus_Missing(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
+	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/gmail/credentials/status", nil)
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
@@ -890,7 +861,7 @@ func TestAuthStart_UsesMetadataScopes(t *testing.T) {
 // --- auth status ---
 
 func TestAuthStatus_NoToken(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
+	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/gmail/auth/status", nil)
 	req.SetPathValue("name", "gmail")
 	rr := httptest.NewRecorder()
@@ -1088,7 +1059,7 @@ func TestAuthStatus_InvalidRefreshTokenRequiresAuth(t *testing.T) {
 // --- reader status ---
 
 func TestReaderStatus_Thunderbird_NotConfigured(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
+	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/readers/thunderbird/status", nil)
 	req.SetPathValue("name", "thunderbird")
 	rr := httptest.NewRecorder()
@@ -1238,14 +1209,6 @@ func TestDisconnectReader_DoesNotStopDaemonWhenInactiveReaderIsRemoved(t *testin
 }
 
 // --- transactions ---
-
-func TestListTransactions_NilStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.ListTransactions, "/api/transactions")
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
-	}
-}
 
 func TestListTransactions_Empty(t *testing.T) {
 	st := &mockStore{transactions: []store.Transaction{}, listResult: store.TransactionListResult{Total: 0}}
@@ -1580,19 +1543,6 @@ func TestGetExtractionDiagnostic_InvalidID(t *testing.T) {
 	}
 }
 
-func TestGetExtractionDiagnostic_NilStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics/11111111-1111-1111-1111-111111111111", nil)
-	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
-	rr := httptest.NewRecorder()
-	h.GetExtractionDiagnostic(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
-	}
-}
-
 func TestUpdateExtractionDiagnosticStatus_InvalidStatus(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 
@@ -1662,36 +1612,6 @@ func TestUpdateExtractionDiagnosticStatus_Conflict(t *testing.T) {
 
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d", rr.Code)
-	}
-}
-
-func TestUpdateExtractionDiagnosticStatus_NilStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-
-	req := httptest.NewRequestWithContext(
-		context.Background(),
-		http.MethodPut,
-		"/api/extraction-diagnostics/11111111-1111-1111-1111-111111111111/status",
-		strings.NewReader(`{"status":"resolved"}`),
-	)
-	req.SetPathValue("id", "11111111-1111-1111-1111-111111111111")
-	rr := httptest.NewRecorder()
-	h.UpdateExtractionDiagnosticStatus(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
-	}
-}
-
-func TestListExtractionDiagnostics_NilStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/extraction-diagnostics", nil)
-	rr := httptest.NewRecorder()
-	h.ListExtractionDiagnostics(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
@@ -1894,14 +1814,6 @@ func TestSearchTransactions_NilSliceReturnsEmptyArray(t *testing.T) {
 	}
 	if len(txns) != 0 {
 		t.Fatalf("expected empty transactions array, got %d entries", len(txns))
-	}
-}
-
-func TestSearchTransactions_NilStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.SearchTransactions, "/api/transactions/search?q=foo")
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
 	}
 }
 
@@ -2280,28 +2192,6 @@ func TestSetBaseCurrency_InvalidCode(t *testing.T) {
 	}
 }
 
-func TestSetBaseCurrency_NoStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/config/base-currency", strings.NewReader(`{"base_currency":"USD"}`))
-	rr := httptest.NewRecorder()
-	h.SetBaseCurrency(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
-	}
-}
-
-func TestGetFacets_NoStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/facets", nil)
-	rr := httptest.NewRecorder()
-	h.GetFacets(rr, req)
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
-	}
-}
-
 func TestGetFacets_ReturnsEmptySlices(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/transactions/facets", nil)
@@ -2370,14 +2260,6 @@ func TestGetFacets_StoreError(t *testing.T) {
 }
 
 // --- labels ---
-
-func TestListLabels_NoStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.ListLabels, "/api/config/labels")
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
-	}
-}
 
 func TestListLabels_Success(t *testing.T) {
 	ms := &mockStore{labels: []store.Label{{Name: "food", Color: "#f59e0b"}}}
@@ -2566,58 +2448,6 @@ func TestExportCategories_IncludesMerchants(t *testing.T) {
 	}
 }
 
-func TestExportCategories_NilStoreReturns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.ExportCategories, "/api/config/categories/export")
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-func TestApplyCategoryByMerchant_NilStoreReturns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	body := strings.NewReader(`{"merchant_pattern":"swiggy"}`)
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/config/categories/Food/apply", body)
-	req.SetPathValue("name", "Food")
-	rr := httptest.NewRecorder()
-
-	h.ApplyCategoryByMerchant(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-func TestRemoveCategoryByMerchant_NilStoreReturns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	body := strings.NewReader(`{"merchant_pattern":"swiggy"}`)
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/config/categories/Food/merchant", body)
-	req.SetPathValue("name", "Food")
-	rr := httptest.NewRecorder()
-
-	h.RemoveCategoryByMerchant(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-// --- buckets ---
-
-func TestListBuckets_Success(t *testing.T) {
-	ms := &mockStore{buckets: []store.Bucket{{Name: "needs", IsDefault: true}}}
-	h := newTestHandlers(t, ms, &mockDaemon{})
-	rr := get(h.ListBuckets, "/api/config/buckets")
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	var resp []store.Bucket
-	decodeJSON(t, rr.Body.String(), &resp)
-	if len(resp) != 1 || resp[0].Name != "needs" {
-		t.Errorf("unexpected response: %v", resp)
-	}
-}
-
 func TestGetBucketMappings_Success(t *testing.T) {
 	ms := &mockStore{bucketMappings: map[string][]string{"Needs": {"rent"}}}
 	h := newTestHandlers(t, ms, &mockDaemon{})
@@ -2687,77 +2517,6 @@ func TestExportBuckets_IncludesMerchants(t *testing.T) {
 	merchants, ok := resp[0]["merchants"].([]any)
 	if !ok || len(merchants) != 1 || merchants[0] != "rent" {
 		t.Fatalf("expected merchants in export, got %#v", resp)
-	}
-}
-
-func TestExportBuckets_NilStoreReturns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	rr := get(h.ExportBuckets, "/api/config/buckets/export")
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-func TestApplyBucketByMerchant_NilStoreReturns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	body := strings.NewReader(`{"merchant_pattern":"rent"}`)
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/config/buckets/Needs/apply", body)
-	req.SetPathValue("name", "Needs")
-	rr := httptest.NewRecorder()
-
-	h.ApplyBucketByMerchant(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-func TestRemoveBucketByMerchant_NilStoreReturns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	body := strings.NewReader(`{"merchant_pattern":"rent"}`)
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/config/buckets/Needs/merchant", body)
-	req.SetPathValue("name", "Needs")
-	rr := httptest.NewRecorder()
-
-	h.RemoveBucketByMerchant(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-// --- extended update transaction ---
-
-func TestUpdateTransaction_InvalidCategory(t *testing.T) {
-	// Store returns empty category list, so any category name is invalid.
-	ms := &mockStore{categories: []store.Category{}}
-	h := newTestHandlers(t, ms, &mockDaemon{})
-	body := strings.NewReader(`{"category":"nonexistent"}`)
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/transactions/11111111-1111-1111-1111-111111111111", body)
-	req.SetPathValue("id", testTransactionID)
-	rr := httptest.NewRecorder()
-	h.UpdateTransaction(rr, req)
-	if rr.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("expected 422, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-// --- scan interval ---
-
-func TestGetScanInterval_Default(t *testing.T) {
-	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/scan-interval", nil)
-	rr := httptest.NewRecorder()
-	h.GetScanInterval(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	var resp map[string]string
-	decodeJSON(t, rr.Body.String(), &resp)
-	if resp["scan_interval"] != "60" {
-		t.Errorf("expected scan_interval=60, got %q", resp["scan_interval"])
 	}
 }
 
@@ -2876,18 +2635,6 @@ func TestGetHeatmap_StoreError_Returns500(t *testing.T) {
 	}
 }
 
-func TestGetHeatmap_NoStore_Returns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/heatmap", nil)
-	rr := httptest.NewRecorder()
-	h.GetHeatmap(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
 func TestGetHeatmap_WithFromTo_Returns200(t *testing.T) {
 	ms := &mockStore{
 		heatmapData: &store.HeatmapData{
@@ -2975,44 +2722,6 @@ func TestGetAnnualHeatmap_StoreError_Returns500(t *testing.T) {
 	}
 }
 
-func TestGetAnnualHeatmap_NoStore_Returns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/stats/heatmap/annual?year=2026", nil)
-	rr := httptest.NewRecorder()
-	h.GetAnnualHeatmap(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-}
-
-// --- rules ---
-
-const validRuleBody = `{
-	"name":"New Rule",
-	"sender_emails":["alerts@example.com"],
-	"amount_regex":"Rs\\.([\\d.]+)",
-	"merchant_regex":"at (.*?) on",
-	"source":{"type":"Credit Card","label":"Example Credit Card","bank":"Example Bank"}
-}`
-
-func TestListRules_Success(t *testing.T) {
-	ms := &mockStore{rules: []store.RuleRow{{ID: "1", Name: "test", AmountRegex: `\d+`, MerchantRegex: `.+`}}}
-	h := newTestHandlers(t, ms, &mockDaemon{})
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/rules", nil)
-	rr := httptest.NewRecorder()
-	h.ListRules(rr, req)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
-	}
-	var resp []store.RuleRow
-	decodeJSON(t, rr.Body.String(), &resp)
-	if len(resp) != 1 {
-		t.Errorf("expected 1 rule, got %d", len(resp))
-	}
-}
-
 func TestListRules_ReturnsSourceObjectAndSenderEmails(t *testing.T) {
 	ms := &mockStore{rules: []store.RuleRow{{
 		ID:              "1",
@@ -3051,15 +2760,14 @@ func TestListRules_ReturnsSourceObjectAndSenderEmails(t *testing.T) {
 	}
 }
 
-func TestListRules_NilStore_Returns503(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/rules", nil)
-	rr := httptest.NewRecorder()
-	h.ListRules(rr, req)
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
-	}
-}
+const validRuleBody = `{
+	"name":"New Rule",
+	"sender_emails":["alerts@example.com"],
+	"amount_regex":"Rs\\.([\\d.]+)",
+	"merchant_regex":"at (.*?) on",
+	"currency_regex":"(INR)",
+	"source":{"type":"Credit Card","label":"Example Card","bank":"Example Bank"}
+}`
 
 func TestCreateRule_Success(t *testing.T) {
 	h := newTestHandlers(t, &mockStore{}, &mockDaemon{})
@@ -3970,38 +3678,11 @@ func TestListBanks(t *testing.T) {
 	}
 }
 
-func (m *mockStore) SeedMCCCodes(_ context.Context, _ []store.MCCEntry) error { return nil }
-func (m *mockStore) SeedMerchantCategories(_ context.Context, _ []store.MerchantCategoryEntry) (int, error) {
-	return 0, nil
-}
-
-func (m *mockStore) LoadCategorySnapshot(_ context.Context) (pkgapi.CategoryResolver, error) {
-	return func(_ string) (string, string) { return "", "" }, nil
-}
-func (m *mockStore) SeedMCCCategories(_ context.Context, _ []string) error { return nil }
 func (m *mockStore) GetSyncStatus(_ context.Context) (store.SyncStatus, error) {
 	if m.syncStatusErr != nil {
 		return store.SyncStatus{}, m.syncStatusErr
 	}
 	return m.syncStatus, nil
-}
-func (m *mockStore) SetSyncStatus(_ context.Context, _ store.SyncStatus) error { return nil }
-
-func TestGetSyncStatus_NoStore(t *testing.T) {
-	h := newTestHandlers(t, nil, &mockDaemon{})
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/config/sync/status", nil)
-	rr := httptest.NewRecorder()
-	h.GetSyncStatus(rr, req)
-
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503, got %d", rr.Code)
-	}
-	var resp map[string]string
-	decodeJSON(t, rr.Body.String(), &resp)
-	if resp["error"] != "database not connected" {
-		t.Fatalf("expected standard error payload, got %#v", resp)
-	}
 }
 
 func TestCategorizeMerchant_OK(t *testing.T) {

--- a/backend/internal/api/handlers_transactions.go
+++ b/backend/internal/api/handlers_transactions.go
@@ -48,10 +48,6 @@ import (
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions [get]
 func (h *Handlers) ListTransactions(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	if invalidKey, ok := firstInvalidFilterParam(
 		r,
 		"merchant",
@@ -119,7 +115,7 @@ func (h *Handlers) ListTransactions(w http.ResponseWriter, r *http.Request) {
 	f.SortBy = r.URL.Query().Get("sort_by")
 	f.SortDir = r.URL.Query().Get("sort_dir")
 
-	txns, result, err := h.store.ListTransactions(r.Context(), f)
+	txns, result, err := h.transactionStore.ListTransactions(r.Context(), f)
 	if err != nil {
 		h.logger.Error("list transactions", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list transactions")
@@ -188,16 +184,11 @@ func containsControlChars(value string) bool {
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id} [get]
 func (h *Handlers) GetTransaction(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	id, ok := uuidPathValue(w, r, "id", "transaction")
 	if !ok {
 		return
 	}
-	txn, err := h.store.GetTransaction(r.Context(), id)
+	txn, err := h.transactionStore.GetTransaction(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "transaction not found")
@@ -213,7 +204,7 @@ func (h *Handlers) GetTransaction(w http.ResponseWriter, r *http.Request) {
 // validateCategory checks that the given category name exists in the store.
 // Returns false and writes an error response if validation fails.
 func (h *Handlers) validateCategory(w http.ResponseWriter, r *http.Request, name string) bool {
-	cats, err := h.store.ListCategories(r.Context())
+	cats, err := h.taxonomyStore.ListCategories(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to validate category")
 		return false
@@ -230,7 +221,7 @@ func (h *Handlers) validateCategory(w http.ResponseWriter, r *http.Request, name
 // validateBucket checks that the given bucket name exists in the store.
 // Returns false and writes an error response if validation fails.
 func (h *Handlers) validateBucket(w http.ResponseWriter, r *http.Request, name string) bool {
-	bkts, err := h.store.ListBuckets(r.Context())
+	bkts, err := h.taxonomyStore.ListBuckets(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to validate bucket")
 		return false
@@ -261,10 +252,6 @@ func (h *Handlers) validateBucket(w http.ResponseWriter, r *http.Request, name s
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id} [put]
 func (h *Handlers) UpdateTransaction(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	id, ok := uuidPathValue(w, r, "id", "transaction")
 	if !ok {
 		return
@@ -291,7 +278,7 @@ func (h *Handlers) UpdateTransaction(w http.ResponseWriter, r *http.Request) {
 		Category:    body.Category,
 		Bucket:      body.Bucket,
 	}
-	if err := h.store.UpdateTransaction(r.Context(), id, u); err != nil {
+	if err := h.transactionStore.UpdateTransaction(r.Context(), id, u); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "transaction not found")
 			return
@@ -301,7 +288,7 @@ func (h *Handlers) UpdateTransaction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tx, err := h.store.GetTransaction(r.Context(), id)
+	tx, err := h.transactionStore.GetTransaction(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "transaction not found")
@@ -330,10 +317,6 @@ func (h *Handlers) UpdateTransaction(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id}/mute [put]
 func (h *Handlers) MuteTransaction(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	id, ok := uuidPathValue(w, r, "id", "transaction")
 	if !ok {
 		return
@@ -346,7 +329,7 @@ func (h *Handlers) MuteTransaction(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if err := h.store.MuteTransaction(r.Context(), id, body.Muted, body.Reason); err != nil {
+	if err := h.muteStore.MuteTransaction(r.Context(), id, body.Muted, body.Reason); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "transaction not found")
 			return
@@ -373,13 +356,7 @@ func (h *Handlers) MuteTransaction(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions/{id}/mute-reason [put]
-//
-//nolint:dupl // structurally similar to UpdateMerchantReason but calls a different store method
 func (h *Handlers) UpdateMuteReason(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	id, ok := uuidPathValue(w, r, "id", "transaction")
 	if !ok {
 		return
@@ -391,7 +368,7 @@ func (h *Handlers) UpdateMuteReason(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if err := h.store.UpdateMuteReason(r.Context(), id, body.Reason); err != nil {
+	if err := h.muteStore.UpdateMuteReason(r.Context(), id, body.Reason); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "transaction not found or not muted")
 			return
@@ -413,11 +390,7 @@ func (h *Handlers) UpdateMuteReason(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /muted-merchants [get]
 func (h *Handlers) ListMutedMerchants(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	merchants, err := h.store.GetMutedMerchantsWithCount(r.Context())
+	merchants, err := h.muteStore.GetMutedMerchantsWithCount(r.Context())
 	if err != nil {
 		h.logger.Error("list muted merchants", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list muted merchants")
@@ -440,10 +413,6 @@ func (h *Handlers) ListMutedMerchants(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /muted-merchants [post]
 func (h *Handlers) MuteByMerchant(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body struct {
 		Pattern string `json:"pattern"`
 		Reason  string `json:"reason"`
@@ -452,7 +421,7 @@ func (h *Handlers) MuteByMerchant(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "request body must be JSON with a non-empty \"pattern\" field")
 		return
 	}
-	if err := h.store.MuteByMerchant(r.Context(), body.Pattern, body.Reason); err != nil {
+	if err := h.muteStore.MuteByMerchant(r.Context(), body.Pattern, body.Reason); err != nil {
 		h.logger.Error("mute by merchant", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to mute merchant")
 		return
@@ -475,13 +444,7 @@ func (h *Handlers) MuteByMerchant(w http.ResponseWriter, r *http.Request) {
 // @Failure 500 {object} ErrorResponse
 // @Failure 503 {object} ErrorResponse
 // @Router /muted-merchants/{id}/reason [put]
-//
-//nolint:dupl // structurally similar to UpdateMuteReason but calls a different store method
 func (h *Handlers) UpdateMerchantReason(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	id, ok := uuidPathValue(w, r, "id", "muted merchant")
 	if !ok {
 		return
@@ -493,7 +456,7 @@ func (h *Handlers) UpdateMerchantReason(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if err := h.store.UpdateMerchantReason(r.Context(), id, body.Reason); err != nil {
+	if err := h.muteStore.UpdateMerchantReason(r.Context(), id, body.Reason); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "muted merchant not found")
 			return
@@ -520,10 +483,6 @@ func (h *Handlers) UpdateMerchantReason(w http.ResponseWriter, r *http.Request) 
 // @Failure 503 {object} ErrorResponse
 // @Router /muted-merchants/{id} [delete]
 func (h *Handlers) DeleteMutedMerchant(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	id, ok := uuidPathValue(w, r, "id", "muted merchant")
 	if !ok {
 		return
@@ -531,9 +490,9 @@ func (h *Handlers) DeleteMutedMerchant(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 	if r.URL.Query().Get("unmute") == queryValueTrue {
-		err = h.store.DeleteMutedMerchantAndUnmute(r.Context(), id)
+		err = h.muteStore.DeleteMutedMerchantAndUnmute(r.Context(), id)
 	} else {
-		err = h.store.DeleteMutedMerchant(r.Context(), id)
+		err = h.muteStore.DeleteMutedMerchant(r.Context(), id)
 	}
 
 	if err != nil {
@@ -564,10 +523,6 @@ func (h *Handlers) DeleteMutedMerchant(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /merchants/categorize [post]
 func (h *Handlers) CategorizeMerchant(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
 	var body struct {
 		Merchant string `json:"merchant"`
 		Category string `json:"category"`
@@ -581,7 +536,7 @@ func (h *Handlers) CategorizeMerchant(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "\"merchant\" must not be empty")
 		return
 	}
-	n, err := h.store.CategorizeMerchant(r.Context(), body.Merchant, body.Category, body.Bucket)
+	n, err := h.muteStore.CategorizeMerchant(r.Context(), body.Merchant, body.Category, body.Bucket)
 	if err != nil {
 		h.logger.Error("categorize merchant", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to categorize merchant")
@@ -604,11 +559,6 @@ func (h *Handlers) CategorizeMerchant(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions/search [get]
 func (h *Handlers) SearchTransactions(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-
 	q := r.URL.Query().Get("q")
 	if containsControlChars(q) {
 		writeError(w, http.StatusBadRequest, "invalid q filter")
@@ -622,7 +572,7 @@ func (h *Handlers) SearchTransactions(w http.ResponseWriter, r *http.Request) {
 		IndividualOnly: r.URL.Query().Get("individual_only") == "1",
 	}
 
-	txns, result, err := h.store.SearchTransactions(r.Context(), q, f)
+	txns, result, err := h.transactionStore.SearchTransactions(r.Context(), q, f)
 	if err != nil {
 		h.logger.Error("search transactions", "error", err)
 		writeError(w, http.StatusInternalServerError, "search failed")
@@ -654,11 +604,7 @@ func (h *Handlers) SearchTransactions(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions/facets [get]
 func (h *Handlers) GetFacets(w http.ResponseWriter, r *http.Request) {
-	if h.store == nil {
-		writeError(w, http.StatusServiceUnavailable, "database not connected")
-		return
-	}
-	facets, err := h.store.GetFacets(r.Context())
+	facets, err := h.transactionStore.GetFacets(r.Context())
 	if err != nil {
 		h.logger.Error("get facets", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to fetch facets")

--- a/backend/internal/api/http_helpers.go
+++ b/backend/internal/api/http_helpers.go
@@ -13,10 +13,8 @@ import (
 
 // currentBaseCurrency returns the base currency from the DB, falling back to INR.
 func (h *Handlers) currentBaseCurrency(ctx context.Context) string {
-	if h.store != nil {
-		if val, err := h.store.GetAppConfig(ctx, "base_currency"); err == nil && val != "" {
-			return val
-		}
+	if val, err := h.settingsStore.GetAppConfig(ctx, "base_currency"); err == nil && val != "" {
+		return val
 	}
 	return defaultBaseCurrency
 }

--- a/backend/internal/api/openapi_types.go
+++ b/backend/internal/api/openapi_types.go
@@ -4,7 +4,7 @@ import "time"
 
 // ErrorResponse is the standard JSON error payload for OpenAPI generation.
 type ErrorResponse struct {
-	Error string `json:"error" example:"database not connected"`
+	Error string `json:"error" example:"internal server error"`
 }
 
 // HealthResponse is the health check payload.

--- a/backend/internal/api/store.go
+++ b/backend/internal/api/store.go
@@ -1,100 +1,21 @@
 package api
 
 import (
-	"context"
-	"encoding/json"
-	"time"
-
 	"github.com/ArionMiles/expensor/backend/internal/store"
-	pkgapi "github.com/ArionMiles/expensor/backend/pkg/api"
 )
 
 // Storer is the subset of store.Store operations used by the API handlers.
 // Using an interface allows handler unit tests to inject a mock without a real database.
 type Storer interface {
-	ListTransactions(ctx context.Context, f store.ListFilter) ([]store.Transaction, store.TransactionListResult, error)
-	GetTransaction(ctx context.Context, id string) (*store.Transaction, error)
-	UpdateDescription(ctx context.Context, id, description string) error
-	AddLabel(ctx context.Context, transactionID, label string) error
-	AddLabels(ctx context.Context, transactionID string, labels []string) error
-	RemoveLabel(ctx context.Context, transactionID, label string) error
-	SearchTransactions(ctx context.Context, query string, f store.ListFilter) ([]store.Transaction, store.TransactionListResult, error)
-	GetStats(ctx context.Context, baseCurrency string) (*store.Stats, error)
-	GetChartData(ctx context.Context) (*store.ChartData, error)
-	GetDashboardData(ctx context.Context) (*store.DashboardData, error)
-	GetSpendingHeatmap(ctx context.Context, from, to *time.Time) (*store.HeatmapData, error)
-	GetAnnualSpend(ctx context.Context, year int) ([]store.DailyBucket, error)
-	GetAppConfig(ctx context.Context, key string) (string, error)
-	SetAppConfig(ctx context.Context, key, value string) error
-	IsMessageProcessed(ctx context.Context, key string) (bool, error)
-	MarkMessageProcessed(ctx context.Context, key string, at time.Time) error
-	SetActiveReader(ctx context.Context, reader string) error
-	GetActiveReader(ctx context.Context) (string, error)
-	SetReaderSecret(ctx context.Context, reader string, secret []byte) error
-	GetReaderSecret(ctx context.Context, reader string) ([]byte, bool, error)
-	SetReaderToken(ctx context.Context, reader string, token []byte) error
-	GetReaderToken(ctx context.Context, reader string) ([]byte, bool, error)
-	DeleteReaderToken(ctx context.Context, reader string) error
-	SetReaderConfig(ctx context.Context, reader string, config json.RawMessage) error
-	GetReaderConfig(ctx context.Context, reader string) (json.RawMessage, bool, error)
-	DeleteReaderRuntime(ctx context.Context, reader string) error
-	GetFacets(ctx context.Context) (*store.Facets, error)
-	// Labels
-	ListLabels(ctx context.Context) ([]store.Label, error)
-	CreateLabel(ctx context.Context, name, color string) error
-	UpdateLabel(ctx context.Context, name, color string) error
-	DeleteLabel(ctx context.Context, name string, removeFromTransactions bool) error
-	ApplyLabelByMerchant(ctx context.Context, label, pattern string) (int64, error)
-	RemoveLabelByMerchant(ctx context.Context, label, pattern string) (int64, error)
-	GetLabelMappings(ctx context.Context) (map[string][]string, error)
-	GetMonthlyBreakdownSpend(ctx context.Context, dimension string, months int) (*store.MonthlyBreakdownData, error)
-	// Categories
-	ListCategories(ctx context.Context) ([]store.Category, error)
-	CreateCategory(ctx context.Context, name, description string) error
-	DeleteCategory(ctx context.Context, name string, removeFromTransactions bool) error
-	ApplyCategoryByMerchant(ctx context.Context, category, pattern string) (int64, error)
-	RemoveCategoryByMerchant(ctx context.Context, category, pattern string) (int64, error)
-	GetCategoryMappings(ctx context.Context) (map[string][]string, error)
-	// Buckets
-	ListBuckets(ctx context.Context) ([]store.Bucket, error)
-	CreateBucket(ctx context.Context, name, description string) error
-	DeleteBucket(ctx context.Context, name string, removeFromTransactions bool) error
-	ApplyBucketByMerchant(ctx context.Context, bucket, pattern string) (int64, error)
-	RemoveBucketByMerchant(ctx context.Context, bucket, pattern string) (int64, error)
-	GetBucketMappings(ctx context.Context) (map[string][]string, error)
-	// Extended transaction update
-	UpdateTransaction(ctx context.Context, id string, u store.TransactionUpdate) error
-	// Muted transactions
-	MuteTransaction(ctx context.Context, id string, muted bool, reason string) error
-	UpdateMuteReason(ctx context.Context, id, reason string) error
-	MuteByMerchant(ctx context.Context, pattern, reason string) error
-	UpdateMerchantReason(ctx context.Context, id, reason string) error
-	ListMutedMerchants(ctx context.Context) ([]store.MutedMerchant, error)
-	GetMutedMerchantsWithCount(ctx context.Context) ([]store.MutedMerchantWithCount, error)
-	DeleteMutedMerchant(ctx context.Context, id string) error
-	UnmuteByPattern(ctx context.Context, pattern string) error
-	DeleteMutedMerchantAndUnmute(ctx context.Context, id string) error
-	// Merchant-wide categorization
-	CategorizeMerchant(ctx context.Context, merchant, category, bucket string) (int, error)
-	// Rules
-	ListRules(ctx context.Context) ([]store.RuleRow, error)
-	GetRule(ctx context.Context, id string) (*store.RuleRow, error)
-	CreateRule(ctx context.Context, r store.RuleRow) (*store.RuleRow, error)
-	UpdateRule(ctx context.Context, id string, r store.RuleRow) (*store.RuleRow, error)
-	DeleteRule(ctx context.Context, id string) error
-	SeedPredefinedRules(ctx context.Context, rules []store.RuleRow) error
-	ImportUserRules(ctx context.Context, rules []store.RuleRow) error
-	// MCC / Community content
-	SeedMCCCodes(ctx context.Context, entries []store.MCCEntry) error
-	SeedMerchantCategories(ctx context.Context, entries []store.MerchantCategoryEntry) (int, error)
-	LoadCategorySnapshot(ctx context.Context) (pkgapi.CategoryResolver, error)
-	SeedMCCCategories(ctx context.Context, names []string) error
-	GetSyncStatus(ctx context.Context) (store.SyncStatus, error)
-	SetSyncStatus(ctx context.Context, status store.SyncStatus) error
-	// Extraction diagnostics
-	ListExtractionDiagnostics(ctx context.Context, filter store.DiagnosticFilter) ([]store.ExtractionDiagnosticRow, error)
-	GetExtractionDiagnostic(ctx context.Context, id string) (*store.ExtractionDiagnosticRow, error)
-	UpdateExtractionDiagnosticStatus(ctx context.Context, id, status string) (*store.ExtractionDiagnosticRow, error)
+	settingsStore
+	analyticsStore
+	transactionStore
+	muteStore
+	taxonomyStore
+	readerRuntimeStore
+	ruleStore
+	syncStore
+	diagnosticStore
 }
 
 // compile-time check: *store.Store must satisfy Storer.

--- a/backend/internal/api/store_capabilities.go
+++ b/backend/internal/api/store_capabilities.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/ArionMiles/expensor/backend/internal/store"
+)
+
+type settingsStore interface {
+	GetAppConfig(ctx context.Context, key string) (string, error)
+	SetAppConfig(ctx context.Context, key, value string) error
+}
+
+type analyticsStore interface {
+	GetStats(ctx context.Context, baseCurrency string) (*store.Stats, error)
+	GetChartData(ctx context.Context) (*store.ChartData, error)
+	GetDashboardData(ctx context.Context) (*store.DashboardData, error)
+	GetSpendingHeatmap(ctx context.Context, from, to *time.Time) (*store.HeatmapData, error)
+	GetAnnualSpend(ctx context.Context, year int) ([]store.DailyBucket, error)
+	GetMonthlyBreakdownSpend(ctx context.Context, dimension string, months int) (*store.MonthlyBreakdownData, error)
+}
+
+type transactionStore interface {
+	ListTransactions(ctx context.Context, f store.ListFilter) ([]store.Transaction, store.TransactionListResult, error)
+	SearchTransactions(ctx context.Context, query string, f store.ListFilter) ([]store.Transaction, store.TransactionListResult, error)
+	GetTransaction(ctx context.Context, id string) (*store.Transaction, error)
+	UpdateTransaction(ctx context.Context, id string, u store.TransactionUpdate) error
+	AddLabels(ctx context.Context, transactionID string, labels []string) error
+	RemoveLabel(ctx context.Context, transactionID, label string) error
+	GetFacets(ctx context.Context) (*store.Facets, error)
+}
+
+type muteStore interface {
+	MuteTransaction(ctx context.Context, id string, muted bool, reason string) error
+	UpdateMuteReason(ctx context.Context, id, reason string) error
+	MuteByMerchant(ctx context.Context, pattern, reason string) error
+	UpdateMerchantReason(ctx context.Context, id, reason string) error
+	GetMutedMerchantsWithCount(ctx context.Context) ([]store.MutedMerchantWithCount, error)
+	DeleteMutedMerchant(ctx context.Context, id string) error
+	DeleteMutedMerchantAndUnmute(ctx context.Context, id string) error
+	CategorizeMerchant(ctx context.Context, merchant, category, bucket string) (int, error)
+}
+
+type taxonomyStore interface {
+	ListLabels(ctx context.Context) ([]store.Label, error)
+	CreateLabel(ctx context.Context, name, color string) error
+	UpdateLabel(ctx context.Context, name, color string) error
+	DeleteLabel(ctx context.Context, name string, removeFromTransactions bool) error
+	ApplyLabelByMerchant(ctx context.Context, label, pattern string) (int64, error)
+	RemoveLabelByMerchant(ctx context.Context, label, pattern string) (int64, error)
+	GetLabelMappings(ctx context.Context) (map[string][]string, error)
+	ListCategories(ctx context.Context) ([]store.Category, error)
+	CreateCategory(ctx context.Context, name, description string) error
+	DeleteCategory(ctx context.Context, name string, removeFromTransactions bool) error
+	ApplyCategoryByMerchant(ctx context.Context, category, pattern string) (int64, error)
+	RemoveCategoryByMerchant(ctx context.Context, category, pattern string) (int64, error)
+	GetCategoryMappings(ctx context.Context) (map[string][]string, error)
+	ListBuckets(ctx context.Context) ([]store.Bucket, error)
+	CreateBucket(ctx context.Context, name, description string) error
+	DeleteBucket(ctx context.Context, name string, removeFromTransactions bool) error
+	ApplyBucketByMerchant(ctx context.Context, bucket, pattern string) (int64, error)
+	RemoveBucketByMerchant(ctx context.Context, bucket, pattern string) (int64, error)
+	GetBucketMappings(ctx context.Context) (map[string][]string, error)
+}
+
+type readerRuntimeStore interface {
+	SetActiveReader(ctx context.Context, reader string) error
+	GetActiveReader(ctx context.Context) (string, error)
+	SetReaderSecret(ctx context.Context, reader string, secret []byte) error
+	GetReaderSecret(ctx context.Context, reader string) ([]byte, bool, error)
+	SetReaderToken(ctx context.Context, reader string, token []byte) error
+	GetReaderToken(ctx context.Context, reader string) ([]byte, bool, error)
+	DeleteReaderToken(ctx context.Context, reader string) error
+	SetReaderConfig(ctx context.Context, reader string, config json.RawMessage) error
+	GetReaderConfig(ctx context.Context, reader string) (json.RawMessage, bool, error)
+	DeleteReaderRuntime(ctx context.Context, reader string) error
+}
+
+type ruleStore interface {
+	ListRules(ctx context.Context) ([]store.RuleRow, error)
+	GetRule(ctx context.Context, id string) (*store.RuleRow, error)
+	CreateRule(ctx context.Context, r store.RuleRow) (*store.RuleRow, error)
+	UpdateRule(ctx context.Context, id string, r store.RuleRow) (*store.RuleRow, error)
+	DeleteRule(ctx context.Context, id string) error
+	ImportUserRules(ctx context.Context, rules []store.RuleRow) error
+}
+
+type syncStore interface {
+	GetSyncStatus(ctx context.Context) (store.SyncStatus, error)
+}
+
+type diagnosticStore interface {
+	ListExtractionDiagnostics(ctx context.Context, filter store.DiagnosticFilter) ([]store.ExtractionDiagnosticRow, error)
+	GetExtractionDiagnostic(ctx context.Context, id string) (*store.ExtractionDiagnosticRow, error)
+	UpdateExtractionDiagnosticStatus(ctx context.Context, id, status string) (*store.ExtractionDiagnosticRow, error)
+}

--- a/backend/internal/api/store_capabilities_test.go
+++ b/backend/internal/api/store_capabilities_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"github.com/ArionMiles/expensor/backend/internal/store"
+)
+
+// Compile-time checks that the concrete store implementations satisfy the
+// smaller capability interfaces used by API handlers.
+var (
+	_ settingsStore      = (*store.Store)(nil)
+	_ analyticsStore     = (*store.Store)(nil)
+	_ transactionStore   = (*store.Store)(nil)
+	_ muteStore          = (*store.Store)(nil)
+	_ taxonomyStore      = (*store.Store)(nil)
+	_ readerRuntimeStore = (*store.Store)(nil)
+	_ ruleStore          = (*store.Store)(nil)
+	_ syncStore          = (*store.Store)(nil)
+	_ diagnosticStore    = (*store.Store)(nil)
+
+	_ settingsStore      = (*store.InstrumentedStore)(nil)
+	_ analyticsStore     = (*store.InstrumentedStore)(nil)
+	_ transactionStore   = (*store.InstrumentedStore)(nil)
+	_ muteStore          = (*store.InstrumentedStore)(nil)
+	_ taxonomyStore      = (*store.InstrumentedStore)(nil)
+	_ readerRuntimeStore = (*store.InstrumentedStore)(nil)
+	_ ruleStore          = (*store.InstrumentedStore)(nil)
+	_ syncStore          = (*store.InstrumentedStore)(nil)
+	_ diagnosticStore    = (*store.InstrumentedStore)(nil)
+)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^9.14.0",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.26.2",
+        "react-router-dom": "^6.30.4",
         "tailwind-merge": "^2.5.2"
       },
       "devDependencies": {
@@ -1110,9 +1110,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -4837,12 +4837,12 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4852,13 +4852,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^9.14.0",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.2",
+    "react-router-dom": "^6.30.4",
     "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {

--- a/tests/component/docker-compose.yml
+++ b/tests/component/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       retries: 20
 
   backend:
-    image: golang:1.26.3-alpine
+    image: golang:1.26.4-alpine
     working_dir: /workspace/backend
     volumes:
       - ../..:/workspace
@@ -66,7 +66,7 @@ services:
         condition: service_healthy
 
   runner:
-    image: golang:1.26.3-alpine
+    image: golang:1.26.4-alpine
     working_dir: /workspace/tests/component
     volumes:
       - ../..:/workspace

--- a/tests/contract/docker-compose.yml
+++ b/tests/contract/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       retries: 20
 
   backend:
-    image: golang:1.26.3-alpine
+    image: golang:1.26.4-alpine
     working_dir: /workspace/backend
     volumes:
       - ../..:/workspace


### PR DESCRIPTION
## Description

Introduce a small consumer-side API store capability slice to show how handler code can depend on narrow interfaces instead of the full `Storer` surface.

This is intentionally limited to config/status endpoints so the pattern is easy to review before applying it more broadly.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

Fixes #(issue)

## Changes Made

- Added narrow API-side store capabilities for app config reads, app config writes, and stats reads.
- Updated status, base-currency, and scan-interval handlers to use those capability interfaces.
- Added compile-time assertions that both `store.Store` and `store.InstrumentedStore` satisfy the new capability interfaces.
- Removed stale `dupl` suppressions after the handler refactor reduced duplication below the lint threshold.

## Testing

- [x] Unit tests pass (`task test:be`)
- [x] Linter passes (`task lint:be:prod`)
- [ ] Manual testing completed
- [x] Added new tests (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The broader `Storer` interface remains in place. This PR is a small representative slice for validating the boundary shape before extending it to other API groups.
