### PR TITLE
Preserve transaction filters during search

### DIFF
--- a/api/openapi/expensor.openapi.yaml
+++ b/api/openapi/expensor.openapi.yaml
@@ -3443,6 +3443,22 @@ paths:
         in: query
         name: exclude_sources
         type: string
+      - description: Source type filter
+        in: query
+        name: source_type
+        type: string
+      - description: Comma-separated source types to exclude
+        in: query
+        name: exclude_source_types
+        type: string
+      - description: Bank filter
+        in: query
+        name: bank
+        type: string
+      - description: Comma-separated banks to exclude
+        in: query
+        name: exclude_banks
+        type: string
       - description: Label filter
         in: query
         name: label
@@ -3491,6 +3507,12 @@ paths:
         in: query
         name: muted_only
         type: integer
+      - description: Return only individually muted transactions when set to 1
+        enum:
+        - 1
+        in: query
+        name: individual_only
+        type: integer
       - description: PostgreSQL DOW weekday filter (0=Sunday...6=Saturday)
         enum:
         - 0
@@ -3514,6 +3536,12 @@ paths:
       - description: IANA timezone used for weekday/hour filters
         in: query
         name: tz
+        type: string
+      - description: Sort field
+        enum:
+        - timestamp
+        in: query
+        name: sort_by
         type: string
       - description: Sort direction
         enum:
@@ -3839,12 +3867,143 @@ paths:
         in: query
         name: page_size
         type: integer
+      - description: Merchant filter
+        in: query
+        name: merchant
+        type: string
+      - description: Category filter
+        in: query
+        name: category
+        type: string
+      - description: Only transactions without a category when set to 1
+        enum:
+        - 1
+        in: query
+        name: category_missing
+        type: integer
+      - description: Comma-separated categories to exclude
+        in: query
+        name: exclude_categories
+        type: string
+      - description: Currency filter
+        in: query
+        name: currency
+        type: string
+      - description: Source filter
+        in: query
+        name: source
+        type: string
+      - description: Comma-separated sources to exclude
+        in: query
+        name: exclude_sources
+        type: string
+      - description: Source type filter
+        in: query
+        name: source_type
+        type: string
+      - description: Comma-separated source types to exclude
+        in: query
+        name: exclude_source_types
+        type: string
+      - description: Bank filter
+        in: query
+        name: bank
+        type: string
+      - description: Comma-separated banks to exclude
+        in: query
+        name: exclude_banks
+        type: string
+      - description: Label filter
+        in: query
+        name: label
+        type: string
+      - description: Only transactions without labels when set to 1
+        enum:
+        - 1
+        in: query
+        name: label_missing
+        type: integer
+      - description: Comma-separated labels to exclude
+        in: query
+        name: exclude_labels
+        type: string
+      - description: Bucket filter
+        in: query
+        name: bucket
+        type: string
+      - description: Only transactions without a bucket when set to 1
+        enum:
+        - 1
+        in: query
+        name: bucket_missing
+        type: integer
+      - description: Comma-separated buckets to exclude
+        in: query
+        name: exclude_buckets
+        type: string
+      - description: RFC3339 start timestamp
+        in: query
+        name: date_from
+        type: string
+      - description: RFC3339 end timestamp
+        in: query
+        name: date_to
+        type: string
       - description: Include muted transactions when set to 1
         enum:
         - 1
         in: query
         name: show_muted
         type: integer
+      - description: Return only muted transactions when set to 1
+        enum:
+        - 1
+        in: query
+        name: muted_only
+        type: integer
+      - description: Return only individually muted transactions when set to 1
+        enum:
+        - 1
+        in: query
+        name: individual_only
+        type: integer
+      - description: PostgreSQL DOW weekday filter (0=Sunday...6=Saturday)
+        enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        in: query
+        name: weekday
+        type: integer
+      - description: Minimum hour filter (0-23)
+        in: query
+        name: hour_from
+        type: integer
+      - description: Maximum hour filter (0-23)
+        in: query
+        name: hour_to
+        type: integer
+      - description: IANA timezone used for weekday/hour filters
+        in: query
+        name: tz
+        type: string
+      - description: Sort field
+        enum:
+        - timestamp
+        in: query
+        name: sort_by
+        type: string
+      - description: Sort direction
+        enum:
+        - asc
+        - desc
+        in: query
+        name: sort_dir
+        type: string
       produces:
       - application/json
       responses:

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -1837,6 +1837,39 @@ func TestSearchTransactions_MutedAndIndividualFlags(t *testing.T) {
 	}
 }
 
+func TestSearchTransactions_ParsesListFilters(t *testing.T) {
+	st := &mockStore{
+		searchResult:     []store.Transaction{},
+		searchListResult: store.TransactionListResult{Total: 0},
+	}
+	h := newTestHandlers(t, st, &mockDaemon{})
+
+	rr := get(
+		h.SearchTransactions,
+		"/api/transactions/search?q=instamart&source_type=Credit%20Card&bank=HDFC"+
+			"&date_from=2026-04-30T18:30:00.000Z&date_to=2026-05-31T18:29:59.999Z&sort_dir=asc",
+	)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if st.searchFilter.SourceType != "Credit Card" {
+		t.Fatalf("source_type = %q, want Credit Card", st.searchFilter.SourceType)
+	}
+	if st.searchFilter.Bank != "HDFC" {
+		t.Fatalf("bank = %q, want HDFC", st.searchFilter.Bank)
+	}
+	if st.searchFilter.From == nil || st.searchFilter.From.UTC().Format(time.RFC3339Nano) != "2026-04-30T18:30:00Z" {
+		t.Fatalf("date_from = %#v", st.searchFilter.From)
+	}
+	if st.searchFilter.To == nil || st.searchFilter.To.UTC().Format(time.RFC3339Nano) != "2026-05-31T18:29:59.999Z" {
+		t.Fatalf("date_to = %#v", st.searchFilter.To)
+	}
+	if st.searchFilter.SortDir != "asc" {
+		t.Fatalf("sort_dir = %q, want asc", st.searchFilter.SortDir)
+	}
+}
+
 func TestSearchTransactions_InvalidControlCharQuery(t *testing.T) {
 	st := &mockStore{}
 	h := newTestHandlers(t, st, &mockDaemon{})

--- a/backend/internal/api/handlers_transactions.go
+++ b/backend/internal/api/handlers_transactions.go
@@ -27,6 +27,10 @@ import (
 // @Param currency query string false "Currency filter"
 // @Param source query string false "Source filter"
 // @Param exclude_sources query string false "Comma-separated sources to exclude"
+// @Param source_type query string false "Source type filter"
+// @Param exclude_source_types query string false "Comma-separated source types to exclude"
+// @Param bank query string false "Bank filter"
+// @Param exclude_banks query string false "Comma-separated banks to exclude"
 // @Param label query string false "Label filter"
 // @Param label_missing query int false "Only transactions without labels when set to 1" Enums(1)
 // @Param exclude_labels query string false "Comma-separated labels to exclude"
@@ -37,10 +41,12 @@ import (
 // @Param date_to query string false "RFC3339 end timestamp"
 // @Param show_muted query int false "Include muted transactions when set to 1" Enums(1)
 // @Param muted_only query int false "Return only muted transactions when set to 1" Enums(1)
+// @Param individual_only query int false "Return only individually muted transactions when set to 1" Enums(1)
 // @Param weekday query int false "PostgreSQL DOW weekday filter (0=Sunday...6=Saturday)" Enums(0,1,2,3,4,5,6)
 // @Param hour_from query int false "Minimum hour filter (0-23)"
 // @Param hour_to query int false "Maximum hour filter (0-23)"
 // @Param tz query string false "IANA timezone used for weekday/hour filters"
+// @Param sort_by query string false "Sort field" Enums(timestamp)
 // @Param sort_dir query string false "Sort direction" Enums(asc,desc)
 // @Success 200 {object} TransactionsListResponse
 // @Failure 400 {object} ErrorResponse
@@ -48,7 +54,35 @@ import (
 // @Failure 503 {object} ErrorResponse
 // @Router /transactions [get]
 func (h *Handlers) ListTransactions(w http.ResponseWriter, r *http.Request) {
-	if invalidKey, ok := firstInvalidFilterParam(
+	if invalidKey, ok := invalidTransactionFilter(r); ok {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid %s filter", invalidKey))
+		return
+	}
+
+	f := h.transactionListFilter(r)
+
+	txns, result, err := h.transactionStore.ListTransactions(r.Context(), f)
+	if err != nil {
+		h.logger.Error("list transactions", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list transactions")
+		return
+	}
+	if txns == nil {
+		txns = []store.Transaction{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"transactions":  txns,
+		"total":         result.Total,
+		"total_amount":  result.TotalAmount,
+		"base_currency": h.currentBaseCurrency(r.Context()),
+		"page":          f.Page,
+		"page_size":     f.PageSize,
+	})
+}
+
+func invalidTransactionFilter(r *http.Request) (string, bool) {
+	return firstInvalidFilterParam(
 		r,
 		"merchant",
 		"category",
@@ -64,11 +98,10 @@ func (h *Handlers) ListTransactions(w http.ResponseWriter, r *http.Request) {
 		"exclude_banks",
 		"exclude_labels",
 		"exclude_buckets",
-	); ok {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid %s filter", invalidKey))
-		return
-	}
+	)
+}
 
+func (h *Handlers) transactionListFilter(r *http.Request) store.ListFilter {
 	f := store.ListFilter{
 		Page:               queryInt(r, "page", 1),
 		PageSize:           queryInt(r, "page_size", 20),
@@ -114,25 +147,7 @@ func (h *Handlers) ListTransactions(w http.ResponseWriter, r *http.Request) {
 	}
 	f.SortBy = r.URL.Query().Get("sort_by")
 	f.SortDir = r.URL.Query().Get("sort_dir")
-
-	txns, result, err := h.transactionStore.ListTransactions(r.Context(), f)
-	if err != nil {
-		h.logger.Error("list transactions", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to list transactions")
-		return
-	}
-	if txns == nil {
-		txns = []store.Transaction{}
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"transactions":  txns,
-		"total":         result.Total,
-		"total_amount":  result.TotalAmount,
-		"base_currency": h.currentBaseCurrency(r.Context()),
-		"page":          f.Page,
-		"page_size":     f.PageSize,
-	})
+	return f
 }
 
 func queryCSV(r *http.Request, key string) []string {
@@ -552,7 +567,34 @@ func (h *Handlers) CategorizeMerchant(w http.ResponseWriter, r *http.Request) {
 // @Param q query string true "Search query"
 // @Param page query int false "1-based page number" default(1)
 // @Param page_size query int false "Page size" default(20)
+// @Param merchant query string false "Merchant filter"
+// @Param category query string false "Category filter"
+// @Param category_missing query int false "Only transactions without a category when set to 1" Enums(1)
+// @Param exclude_categories query string false "Comma-separated categories to exclude"
+// @Param currency query string false "Currency filter"
+// @Param source query string false "Source filter"
+// @Param exclude_sources query string false "Comma-separated sources to exclude"
+// @Param source_type query string false "Source type filter"
+// @Param exclude_source_types query string false "Comma-separated source types to exclude"
+// @Param bank query string false "Bank filter"
+// @Param exclude_banks query string false "Comma-separated banks to exclude"
+// @Param label query string false "Label filter"
+// @Param label_missing query int false "Only transactions without labels when set to 1" Enums(1)
+// @Param exclude_labels query string false "Comma-separated labels to exclude"
+// @Param bucket query string false "Bucket filter"
+// @Param bucket_missing query int false "Only transactions without a bucket when set to 1" Enums(1)
+// @Param exclude_buckets query string false "Comma-separated buckets to exclude"
+// @Param date_from query string false "RFC3339 start timestamp"
+// @Param date_to query string false "RFC3339 end timestamp"
 // @Param show_muted query int false "Include muted transactions when set to 1" Enums(1)
+// @Param muted_only query int false "Return only muted transactions when set to 1" Enums(1)
+// @Param individual_only query int false "Return only individually muted transactions when set to 1" Enums(1)
+// @Param weekday query int false "PostgreSQL DOW weekday filter (0=Sunday...6=Saturday)" Enums(0,1,2,3,4,5,6)
+// @Param hour_from query int false "Minimum hour filter (0-23)"
+// @Param hour_to query int false "Maximum hour filter (0-23)"
+// @Param tz query string false "IANA timezone used for weekday/hour filters"
+// @Param sort_by query string false "Sort field" Enums(timestamp)
+// @Param sort_dir query string false "Sort direction" Enums(asc,desc)
 // @Success 200 {object} TransactionsSearchResponse
 // @Failure 400 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
@@ -564,13 +606,11 @@ func (h *Handlers) SearchTransactions(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid q filter")
 		return
 	}
-	f := store.ListFilter{
-		Page:           queryInt(r, "page", 1),
-		PageSize:       queryInt(r, "page_size", 20),
-		ShowMuted:      r.URL.Query().Get("show_muted") == "1",
-		MutedOnly:      r.URL.Query().Get("muted_only") == "1",
-		IndividualOnly: r.URL.Query().Get("individual_only") == "1",
+	if invalidKey, ok := invalidTransactionFilter(r); ok {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid %s filter", invalidKey))
+		return
 	}
+	f := h.transactionListFilter(r)
 
 	txns, result, err := h.transactionStore.SearchTransactions(r.Context(), q, f)
 	if err != nil {

--- a/backend/internal/store/store_test.go
+++ b/backend/internal/store/store_test.go
@@ -1190,6 +1190,62 @@ func TestSearchTransactions_HonorsAscendingSort(t *testing.T) {
 	}
 }
 
+func TestSearchTransactions_AppliesDateAndSourceTypeFilters(t *testing.T) {
+	ts := newTestStore(t)
+	defer ts.cleanup()
+	ctx := context.Background()
+
+	for _, params := range []store.InsertParams{
+		{
+			MessageID:    "srch-filter-match",
+			Amount:       100,
+			Currency:     "INR",
+			MerchantInfo: "Instamart May",
+			SourceType:   "Credit Card",
+			Timestamp:    time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			MessageID:    "srch-filter-outside-date",
+			Amount:       200,
+			Currency:     "INR",
+			MerchantInfo: "Instamart April",
+			SourceType:   "Credit Card",
+			Timestamp:    time.Date(2026, time.April, 15, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			MessageID:    "srch-filter-wrong-source",
+			Amount:       300,
+			Currency:     "INR",
+			MerchantInfo: "Instamart UPI",
+			SourceType:   "UPI",
+			Timestamp:    time.Date(2026, time.May, 20, 12, 0, 0, 0, time.UTC),
+		},
+	} {
+		if _, err := ts.InsertForTest(ctx, params); err != nil {
+			t.Fatalf("InsertForTest: %v", err)
+		}
+	}
+
+	from := time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.May, 31, 23, 59, 59, 0, time.UTC)
+	rows, result, err := ts.SearchTransactions(ctx, "instamart", store.ListFilter{
+		Page:       1,
+		PageSize:   20,
+		SourceType: "Credit Card",
+		From:       &from,
+		To:         &to,
+	})
+	if err != nil {
+		t.Fatalf("SearchTransactions: %v", err)
+	}
+	if result.Total != 1 || len(rows) != 1 {
+		t.Fatalf("expected one filtered result, got total=%d rows=%+v", result.Total, rows)
+	}
+	if rows[0].MessageID != "srch-filter-match" {
+		t.Fatalf("message_id = %q, want srch-filter-match", rows[0].MessageID)
+	}
+}
+
 func TestSearchTransactions_EmptyQuery(t *testing.T) {
 	ts := newTestStore(t)
 	defer ts.cleanup()

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -33,11 +33,6 @@ type Config struct {
 	// Default: same as BASE_URL
 	FrontendURL string `envconfig:"FRONTEND_URL"`
 
-	// BaseCurrency is the primary currency used for aggregate stats.
-	// Environment variable: EXPENSOR_BASE_CURRENCY
-	// Default: INR
-	BaseCurrency string `envconfig:"EXPENSOR_BASE_CURRENCY" default:"INR"`
-
 	// ScanInterval is the polling interval in seconds for all readers.
 	// Environment variable: EXPENSOR_SCAN_INTERVAL
 	// Default: 60

--- a/backend/pkg/config/config_test.go
+++ b/backend/pkg/config/config_test.go
@@ -31,8 +31,8 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	if cfg.Port != 8080 || cfg.BaseURL != "http://localhost:8080" || cfg.FrontendURL != cfg.BaseURL {
 		t.Fatalf("server defaults: got port=%d base=%q frontend=%q", cfg.Port, cfg.BaseURL, cfg.FrontendURL)
 	}
-	if cfg.BaseCurrency != "INR" || cfg.ScanInterval != 60 || cfg.LookbackDays != 180 {
-		t.Fatalf("application defaults: got currency=%q scan=%d lookback=%d", cfg.BaseCurrency, cfg.ScanInterval, cfg.LookbackDays)
+	if cfg.ScanInterval != 60 || cfg.LookbackDays != 180 {
+		t.Fatalf("application defaults: got scan=%d lookback=%d", cfg.ScanInterval, cfg.LookbackDays)
 	}
 	if cfg.Postgres.Port != 5432 || cfg.Postgres.SSLMode != "disable" || cfg.Postgres.BatchSize != 10 ||
 		cfg.Postgres.FlushInterval != 30 || cfg.Postgres.MaxPoolSize != 10 {
@@ -124,7 +124,6 @@ func clearConfigEnv(t *testing.T) {
 		"PORT",
 		"BASE_URL",
 		"FRONTEND_URL",
-		"EXPENSOR_BASE_CURRENCY",
 		"EXPENSOR_SCAN_INTERVAL",
 		"EXPENSOR_LOOKBACK_DAYS",
 		"EXPENSOR_STATIC_DIR",

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const axiosMocks = vi.hoisted(() => {
+  const get = vi.fn()
+  return {
+    get,
+    create: vi.fn(() => ({
+      get,
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      interceptors: {
+        response: {
+          use: vi.fn(),
+        },
+      },
+    })),
+  }
+})
+
+vi.mock('axios', () => ({
+  default: {
+    create: axiosMocks.create,
+    isAxiosError: vi.fn(() => false),
+  },
+}))
+
+import { api } from './client'
+
+describe('transactions API', () => {
+  beforeEach(() => {
+    axiosMocks.get.mockReset()
+  })
+
+  it('includes active filters in search requests', () => {
+    api.transactions.search('instamart', {
+      page: 1,
+      page_size: 50,
+      source_type: 'Credit Card',
+      bank: 'HDFC',
+      date_from: '2026-04-30T18:30:00.000Z',
+      date_to: '2026-05-31T18:29:59.999Z',
+      sort_dir: 'asc',
+    })
+
+    expect(axiosMocks.get).toHaveBeenCalledOnce()
+    const requestURL = axiosMocks.get.mock.calls[0][0] as string
+    const url = new URL(requestURL, 'http://localhost')
+
+    expect(url.pathname).toBe('/transactions/search')
+    expect(url.searchParams.get('q')).toBe('instamart')
+    expect(url.searchParams.get('page_size')).toBe('50')
+    expect(url.searchParams.get('source_type')).toBe('Credit Card')
+    expect(url.searchParams.get('bank')).toBe('HDFC')
+    expect(url.searchParams.get('date_from')).toBe('2026-04-30T18:30:00.000Z')
+    expect(url.searchParams.get('date_to')).toBe('2026-05-31T18:29:59.999Z')
+    expect(url.searchParams.get('sort_dir')).toBe('asc')
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -59,6 +59,47 @@ apiClient.interceptors.response.use(
   },
 )
 
+function transactionFilterParams(filters: TransactionFilters): URLSearchParams {
+  const params = new URLSearchParams()
+  if (filters.page) params.set('page', String(filters.page))
+  if (filters.page_size) params.set('page_size', String(filters.page_size))
+  if (filters.category) params.set('category', filters.category)
+  if (filters.category_missing) params.set('category_missing', '1')
+  if (filters.exclude_categories?.length)
+    params.set('exclude_categories', filters.exclude_categories.join(','))
+  if (filters.currency) params.set('currency', filters.currency)
+  if (filters.source) params.set('source', filters.source)
+  if (filters.exclude_sources?.length)
+    params.set('exclude_sources', filters.exclude_sources.join(','))
+  if (filters.source_type) params.set('source_type', filters.source_type)
+  if (filters.exclude_source_types?.length)
+    params.set('exclude_source_types', filters.exclude_source_types.join(','))
+  if (filters.bank) params.set('bank', filters.bank)
+  if (filters.exclude_banks?.length) params.set('exclude_banks', filters.exclude_banks.join(','))
+  if (filters.bucket) params.set('bucket', filters.bucket)
+  if (filters.bucket_missing) params.set('bucket_missing', '1')
+  if (filters.exclude_buckets?.length)
+    params.set('exclude_buckets', filters.exclude_buckets.join(','))
+  if (filters.merchant) params.set('merchant', filters.merchant)
+  if (filters.label) params.set('label', filters.label)
+  if (filters.label_missing) params.set('label_missing', '1')
+  if (filters.exclude_labels?.length) params.set('exclude_labels', filters.exclude_labels.join(','))
+  if (filters.date_from) params.set('date_from', filters.date_from)
+  if (filters.date_to) params.set('date_to', filters.date_to)
+  if (filters.sort_by) params.set('sort_by', filters.sort_by)
+  if (filters.sort_dir) params.set('sort_dir', filters.sort_dir)
+  if (filters.show_muted) params.set('show_muted', '1')
+  if (filters.muted_only) params.set('muted_only', '1')
+  if (filters.individual_only) params.set('individual_only', '1')
+  if (filters.hour_from !== undefined && filters.hour_from >= 0)
+    params.set('hour_from', String(filters.hour_from))
+  if (filters.hour_to !== undefined && filters.hour_to >= 0)
+    params.set('hour_to', String(filters.hour_to))
+  if (filters.weekday !== undefined) params.set('weekday', String(filters.weekday))
+  if (filters.tz) params.set('tz', filters.tz)
+  return params
+}
+
 export const api = {
   health: {
     get: () => apiClient.get<HealthResponse>('/health'),
@@ -281,51 +322,13 @@ export const api = {
 
   transactions: {
     list: (filters: TransactionFilters = {}) => {
-      const params = new URLSearchParams()
-      if (filters.page) params.set('page', String(filters.page))
-      if (filters.page_size) params.set('page_size', String(filters.page_size))
-      if (filters.category) params.set('category', filters.category)
-      if (filters.category_missing) params.set('category_missing', '1')
-      if (filters.exclude_categories?.length)
-        params.set('exclude_categories', filters.exclude_categories.join(','))
-      if (filters.currency) params.set('currency', filters.currency)
-      if (filters.source) params.set('source', filters.source)
-      if (filters.exclude_sources?.length)
-        params.set('exclude_sources', filters.exclude_sources.join(','))
-      if (filters.source_type) params.set('source_type', filters.source_type)
-      if (filters.exclude_source_types?.length)
-        params.set('exclude_source_types', filters.exclude_source_types.join(','))
-      if (filters.bank) params.set('bank', filters.bank)
-      if (filters.exclude_banks?.length)
-        params.set('exclude_banks', filters.exclude_banks.join(','))
-      if (filters.bucket) params.set('bucket', filters.bucket)
-      if (filters.bucket_missing) params.set('bucket_missing', '1')
-      if (filters.exclude_buckets?.length)
-        params.set('exclude_buckets', filters.exclude_buckets.join(','))
-      if (filters.merchant) params.set('merchant', filters.merchant)
-      if (filters.label) params.set('label', filters.label)
-      if (filters.label_missing) params.set('label_missing', '1')
-      if (filters.exclude_labels?.length)
-        params.set('exclude_labels', filters.exclude_labels.join(','))
-      if (filters.date_from) params.set('date_from', filters.date_from)
-      if (filters.date_to) params.set('date_to', filters.date_to)
-      if (filters.sort_by) params.set('sort_by', filters.sort_by)
-      if (filters.sort_dir) params.set('sort_dir', filters.sort_dir)
-      if (filters.show_muted) params.set('show_muted', '1')
-      if (filters.muted_only) params.set('muted_only', '1')
-      if (filters.individual_only) params.set('individual_only', '1')
-      if (filters.hour_from !== undefined && filters.hour_from >= 0)
-        params.set('hour_from', String(filters.hour_from))
-      if (filters.hour_to !== undefined && filters.hour_to >= 0)
-        params.set('hour_to', String(filters.hour_to))
-      if (filters.weekday !== undefined) params.set('weekday', String(filters.weekday))
-      if (filters.tz) params.set('tz', filters.tz)
+      const params = transactionFilterParams(filters)
       return apiClient.get<TransactionsResponse>(`/transactions?${params.toString()}`)
     },
 
-    search: (q: string, page = 1, pageSize = 20, showMuted = false) => {
-      const params = new URLSearchParams({ q, page: String(page), page_size: String(pageSize) })
-      if (showMuted) params.set('show_muted', '1')
+    search: (q: string, filters: TransactionFilters = {}) => {
+      const params = transactionFilterParams(filters)
+      params.set('q', q)
       return apiClient.get<TransactionsResponse>(`/transactions/search?${params.toString()}`)
     },
 

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -27,8 +27,8 @@ export const queryKeys = {
   readerStatus: (name: string) => ['readers', name, 'status'] as const,
   facets: ['transactions', 'facets'] as const,
   transactions: (filters: TransactionFilters) => ['transactions', filters] as const,
-  transactionSearch: (q: string, page: number, pageSize: number) =>
-    ['transactions', 'search', q, page, pageSize] as const,
+  transactionSearch: (q: string, filters: TransactionFilters) =>
+    ['transactions', 'search', q, filters] as const,
   transaction: (id: string) => ['transactions', id] as const,
   extractionDiagnostics: (status: ExtractionDiagnosticListStatus) =>
     ['extraction-diagnostics', status] as const,
@@ -177,18 +177,13 @@ export function useFacets() {
 
 export function useTransactions(filters: TransactionFilters, searchQuery: string) {
   const isSearch = searchQuery.trim().length > 0
-  const page = filters.page ?? 1
-  const pageSize = filters.page_size ?? 20
 
   return useQuery({
     queryKey: isSearch
-      ? queryKeys.transactionSearch(searchQuery, page, pageSize)
+      ? queryKeys.transactionSearch(searchQuery, filters)
       : queryKeys.transactions(filters),
     queryFn: isSearch
-      ? () =>
-          api.transactions
-            .search(searchQuery, page, pageSize, !!filters.show_muted)
-            .then((r) => r.data)
+      ? () => api.transactions.search(searchQuery, filters).then((r) => r.data)
       : () => api.transactions.list(filters).then((r) => r.data),
     placeholderData: (prev) => prev,
   })

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -20,6 +20,8 @@ function filterTransactions(url: URL) {
   const sourceType = url.searchParams.get('source_type')
   const bank = url.searchParams.get('bank')
   const label = url.searchParams.get('label')
+  const dateFrom = url.searchParams.get('date_from')
+  const dateTo = url.searchParams.get('date_to')
 
   return seededTransactions.filter((transaction) => {
     if (q) {
@@ -57,6 +59,14 @@ function filterTransactions(url: URL) {
     }
 
     if (label && !transaction.labels.includes(label)) {
+      return false
+    }
+
+    if (dateFrom && new Date(transaction.timestamp) < new Date(dateFrom)) {
+      return false
+    }
+
+    if (dateTo && new Date(transaction.timestamp) > new Date(dateTo)) {
       return false
     }
 


### PR DESCRIPTION
## Description

Preserve active transaction filters when keyword search switches the UI to the search endpoint. Also remove the obsolete environment-configured base currency default because onboarding requires a persisted user selection.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

Fixes #(issue)

## Changes Made

- Reuse one frontend query serializer for transaction listing and search so date, source, bank, taxonomy, mute, time, pagination, and sorting filters are retained.
- Reuse one backend transaction filter parser and validator for both endpoints, and document the search filters in OpenAPI.
- Remove `EXPENSOR_BASE_CURRENCY` and its `INR` default from environment configuration while keeping persisted setup preferences authoritative.
- Add request-level and database-backed regression coverage for combined keyword, date, and source-type filtering.

## Testing

- [x] Unit tests pass (`task test:be`)
- [x] Linter passes (`task lint:be:prod` and `task lint:fe`)
- [ ] Manual testing completed
- [x] Added new tests (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Verification completed with `task test`, `task lint:be:prod`, `task lint:fe`, `task fmt:fe:check`, and `task openapi:check`.
