### PR TITLE
Rename legacy migration bookkeeping table

### DIFF
--- a/backend/migrations/migrations.go
+++ b/backend/migrations/migrations.go
@@ -22,12 +22,12 @@ var FS embed.FS
 func Run(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) error {
 	// Bootstrap the tracking table before anything else.
 	if _, err := pool.Exec(ctx, `
-		CREATE TABLE IF NOT EXISTS schema_migrations (
+		CREATE TABLE IF NOT EXISTS legacy_schema_migrations (
 			filename   TEXT PRIMARY KEY,
 			applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)
 	`); err != nil {
-		return fmt.Errorf("creating schema_migrations table: %w", err)
+		return fmt.Errorf("creating legacy_schema_migrations table: %w", err)
 	}
 
 	entries, err := fs.ReadDir(FS, ".")
@@ -46,7 +46,7 @@ func Run(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) error {
 	for _, filename := range files {
 		var applied bool
 		if err := pool.QueryRow(ctx,
-			`SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)`, filename,
+			`SELECT EXISTS(SELECT 1 FROM legacy_schema_migrations WHERE filename = $1)`, filename,
 		).Scan(&applied); err != nil {
 			return fmt.Errorf("checking migration %s: %w", filename, err)
 		}
@@ -65,7 +65,7 @@ func Run(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) error {
 			return fmt.Errorf("applying migration %s: %w", filename, err)
 		}
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO schema_migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`, filename,
+			`INSERT INTO legacy_schema_migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING`, filename,
 		); err != nil {
 			return fmt.Errorf("recording migration %s: %w", filename, err)
 		}

--- a/backend/migrations/migrations_test.go
+++ b/backend/migrations/migrations_test.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func newMigrationTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	ctx := context.Background()
+	ctr, err := tcpostgres.Run(ctx, "postgres:16-alpine",
+		tcpostgres.WithDatabase("expensor_test"),
+		tcpostgres.WithUsername("expensor"),
+		tcpostgres.WithPassword("expensor"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+
+	dsn, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("connection string: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("open pool: %v", err)
+	}
+
+	t.Cleanup(func() {
+		pool.Close()
+		_ = ctr.Terminate(context.Background())
+	})
+
+	return pool
+}
+
+func TestRunUsesLegacySchemaMigrationsTable(t *testing.T) {
+	ctx := context.Background()
+	pool := newMigrationTestPool(t)
+
+	if err := Run(ctx, pool, slog.New(slog.NewTextHandler(io.Discard, nil))); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var exists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = 'public'
+			  AND table_name = 'legacy_schema_migrations'
+		)
+	`).Scan(&exists); err != nil {
+		t.Fatalf("check table exists: %v", err)
+	}
+	if !exists {
+		t.Fatal("legacy_schema_migrations table not created")
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM legacy_schema_migrations`).Scan(&count); err != nil {
+		t.Fatalf("count legacy migrations: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("expected at least one recorded migration")
+	}
+}

--- a/backend/pkg/writer/postgres/migration_legacy_test.go
+++ b/backend/pkg/writer/postgres/migration_legacy_test.go
@@ -1,0 +1,42 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewWriterUsesLegacySchemaMigrationsTable(t *testing.T) {
+	w := newTestWriter(t, Config{})
+	defer w.Close()
+
+	ctx := context.Background()
+	var legacyExists bool
+	if err := w.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = 'public'
+			  AND table_name = 'legacy_schema_migrations'
+		)
+	`).Scan(&legacyExists); err != nil {
+		t.Fatalf("check legacy table exists: %v", err)
+	}
+	if !legacyExists {
+		t.Fatal("legacy_schema_migrations table not present after writer bootstrap")
+	}
+
+	var oldExists bool
+	if err := w.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = 'public'
+			  AND table_name = 'schema_migrations'
+		)
+	`).Scan(&oldExists); err != nil {
+		t.Fatalf("check old table exists: %v", err)
+	}
+	if oldExists {
+		t.Fatal("schema_migrations table should not be present after phase 1")
+	}
+}

--- a/docs/superpowers/plans/2026-06-15-golang-migrate-phase-1.md
+++ b/docs/superpowers/plans/2026-06-15-golang-migrate-phase-1.md
@@ -1,0 +1,229 @@
+# Golang-Migrate Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the current custom migration bookkeeping table so `schema_migrations` is available for the later `golang-migrate` release.
+
+**Architecture:** Keep the existing sequential migration runner in place for now, but change it to track applied files in `legacy_schema_migrations` instead of `schema_migrations`. Cover both the runner and the writer bootstrap path with tests so the next release can assume the canonical `schema_migrations` name is free, while current databases continue to boot exactly as before.
+
+**Tech Stack:** Go, PostgreSQL, pgx, embedded SQL migrations, Task
+
+---
+
+### Task 1: Rename the migration tracking table in the runner
+
+**Files:**
+- Create: `backend/internal/migration/migration_test.go`
+- Modify: `backend/internal/migration/migration.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create a migration-package integration test that boots a temporary Postgres container, runs `Run`, and asserts the runner created and populated `legacy_schema_migrations` instead of `schema_migrations`.
+
+```go
+func newMigrationTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	ctx := context.Background()
+	ctr, err := tcpostgres.Run(ctx, "postgres:16-alpine",
+		tcpostgres.WithDatabase("expensor_test"),
+		tcpostgres.WithUsername("expensor"),
+		tcpostgres.WithPassword("expensor"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+
+	dsn, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("connection string: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		_ = ctr.Terminate(ctx)
+		t.Fatalf("open pool: %v", err)
+	}
+
+	t.Cleanup(func() {
+		pool.Close()
+		_ = ctr.Terminate(context.Background())
+	})
+	return pool
+}
+
+func TestRunUsesLegacySchemaMigrationsTable(t *testing.T) {
+	ctx := context.Background()
+	pool := newMigrationTestPool(t)
+
+	if err := Run(ctx, pool, migrations.FS, slog.New(slog.NewTextHandler(io.Discard, nil))); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var exists bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = 'public'
+			  AND table_name = 'legacy_schema_migrations'
+		)
+	`).Scan(&exists); err != nil {
+		t.Fatalf("check table exists: %v", err)
+	}
+	if !exists {
+		t.Fatal("legacy_schema_migrations table not created")
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM legacy_schema_migrations`).Scan(&count); err != nil {
+		t.Fatalf("count legacy migrations: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("expected at least one recorded migration")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./backend/internal/migration -run TestRunUsesLegacySchemaMigrationsTable -v`
+Expected: FAIL because the runner still creates and queries `schema_migrations`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Change the table name literals in `backend/internal/migration/migration.go` from `schema_migrations` to `legacy_schema_migrations`, including the create-table statement, the existence check, and the insert.
+
+```sql
+CREATE TABLE IF NOT EXISTS legacy_schema_migrations (
+	filename   TEXT PRIMARY KEY,
+	applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)
+```
+
+```sql
+SELECT EXISTS(SELECT 1 FROM legacy_schema_migrations WHERE filename = $1)
+```
+
+```sql
+INSERT INTO legacy_schema_migrations (filename) VALUES ($1) ON CONFLICT DO NOTHING
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./backend/internal/migration -run TestRunUsesLegacySchemaMigrationsTable -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/migration/migration.go backend/internal/migration/migration_test.go
+git commit -m "Rename legacy migration bookkeeping table"
+```
+
+### Task 2: Cover the writer bootstrap path and update migration comments
+
+**Files:**
+- Modify: `backend/pkg/writer/postgres/postgres_test.go`
+- Modify: `backend/migrations/001_init.sql`
+- Modify: `backend/internal/migration/migration.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a writer integration test that creates a fresh writer, then checks that the bootstrap migration table is `legacy_schema_migrations` and that `schema_migrations` does not exist.
+
+```go
+func TestNewWriterUsesLegacySchemaMigrationsTable(t *testing.T) {
+	w := newTestWriter(t, Config{})
+	defer w.Close()
+
+	ctx := context.Background()
+	var legacyExists bool
+	if err := w.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = 'public'
+			  AND table_name = 'legacy_schema_migrations'
+		)
+	`).Scan(&legacyExists); err != nil {
+		t.Fatalf("check legacy table exists: %v", err)
+	}
+	if !legacyExists {
+		t.Fatal("legacy_schema_migrations table not present after writer bootstrap")
+	}
+
+	var oldExists bool
+	if err := w.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = 'public'
+			  AND table_name = 'schema_migrations'
+		)
+	`).Scan(&oldExists); err != nil {
+		t.Fatalf("check old table exists: %v", err)
+	}
+	if oldExists {
+		t.Fatal("schema_migrations table should not be present after phase 1")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./backend/pkg/writer/postgres -run TestNewWriterUsesLegacySchemaMigrationsTable -v`
+Expected: FAIL because the writer bootstrap still records to `schema_migrations`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Update the runner comment in `backend/internal/migration/migration.go` and the bootstrap comment in `backend/migrations/001_init.sql` so they describe `legacy_schema_migrations` instead of the retired table name.
+
+```sql
+-- This file is intentionally idempotent so the migration runner can safely
+-- re-apply it if the legacy_schema_migrations record is lost.
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./backend/pkg/writer/postgres -run TestNewWriterUsesLegacySchemaMigrationsTable -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/pkg/writer/postgres/postgres_test.go backend/migrations/001_init.sql backend/internal/migration/migration.go
+git commit -m "Update migration bootstrap coverage"
+```
+
+### Task 3: Verify the phase boundary is ready for the next release
+
+**Files:**
+- Review only: `backend/internal/migration/migration.go`, `backend/pkg/writer/postgres/postgres.go`, `backend/internal/migration/migration_test.go`, `backend/pkg/writer/postgres/postgres_test.go`
+
+- [ ] **Step 1: Run the backend checks**
+
+Run:
+```bash
+task test:be
+task lint:be:prod
+```
+Expected: both pass with zero issues.
+
+- [ ] **Step 2: Run the focused migration smoke tests**
+
+Run:
+```bash
+go test ./backend/internal/migration ./backend/pkg/writer/postgres -run 'TestRunUsesLegacySchemaMigrationsTable|TestNewWriterUsesLegacySchemaMigrationsTable' -v
+```
+Expected: PASS, and no production code path mentions `schema_migrations` as the bookkeeping table.
+
+- [ ] **Step 3: Stop**
+
+Do not start `golang-migrate` adoption in this PR. Phase 2 gets its own branch after this one is merged and released.

--- a/docs/superpowers/specs/2026-06-15-golang-migrate-schema-shift-design.md
+++ b/docs/superpowers/specs/2026-06-15-golang-migrate-schema-shift-design.md
@@ -1,0 +1,100 @@
+# Golang-Migrate Schema Shift Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the custom SQL migration runner with `golang-migrate` while moving all application tables from `public` into an `expensor` schema and preserving a safe, one-time startup bridge between the old and new layouts.
+
+**Architecture:** The work is split into three release-separated phases. Phase 1 renames the current custom migration bookkeeping table so the canonical `schema_migrations` name is free for `golang-migrate`. Phase 2 introduces a startup-owned compatibility bridge that creates `expensor`, recreates the application schema there, copies data across from `public`, validates the result, and then hands off to `golang-migrate` using the default `schema_migrations` table in `expensor`. Phase 3 removes the bridge and the legacy runner, leaving only `golang-migrate` plus the `expensor` schema.
+
+**Tech Stack:** Go, PostgreSQL, `golang-migrate/migrate`, embedded `io/fs` migrations, pgx, Task
+
+---
+
+## Phase 1: Free the `schema_migrations` Name
+
+Phase 1 is a compatibility-only PR. Its purpose is to rename the current filename-tracking table used by the custom runner so the next release can adopt `golang-migrate` without colliding with the existing table name.
+
+### Requirements
+
+- Rename the current tracking table from `schema_migrations` to `legacy_schema_migrations`.
+- Keep the current sequential migration runner working against the renamed table.
+- Preserve the existing idempotent startup behavior for current databases.
+- Ensure the rename is safe for already-migrated databases and fresh databases.
+
+### Validation
+
+- Existing backend tests continue to pass.
+- Startup migration tests confirm the old runner still records applied filenames, but under the renamed table.
+- The application no longer creates or reads a table named `schema_migrations` during phase 1.
+
+---
+
+## Phase 2: Adopt Golang-Migrate and Move Tables to `expensor`
+
+Phase 2 is a new release after phase 1 ships. It introduces the `expensor` schema and a one-time startup bridge that migrates existing databases from the `public` layout to the new schema before the app uses `golang-migrate` normally.
+
+### Requirements
+
+- Create the `expensor` schema if it does not exist.
+- Recreate the application tables in `expensor`.
+- Copy existing data from `public` tables into the `expensor` tables.
+- Keep the bridge startup-owned and automatic for existing databases.
+- Treat the bridge as one-time migration code, not as part of the permanent migration runner.
+- Use `golang-migrate` after the bridge completes successfully.
+- Use the default `schema_migrations` table for `golang-migrate` in the new schema.
+- Preserve a rollback path only during the migration window. If the bridge fails before it commits, the original `public` schema remains usable.
+
+### Bridge Behavior
+
+- The bridge should run before application code opens a long-lived store connection.
+- The bridge should run in a transaction or equivalent atomic unit so a failure leaves the old layout intact.
+- The bridge should validate that the new schema can see the copied data before committing.
+- The bridge should not introduce dual-write behavior or ongoing synchronization between `public` and `expensor`.
+- The bridge should be isolated behind a dedicated startup helper so phase 3 can remove it cleanly.
+
+### Migration File Expectations
+
+- Application migrations should follow `golang-migrate` conventions, including `.up.sql` and `.down.sql` files.
+- Schema-qualified SQL should target `expensor` where needed.
+- The compatibility bridge should be separate from the permanent migration files so its removal does not disturb normal schema evolution.
+
+### Validation
+
+- Fresh-install tests create `expensor`, apply migrations, and verify the app works against the new schema.
+- Existing-database tests verify the bridge copies data forward correctly.
+- Failure tests verify a bridge error leaves the original `public` schema intact.
+- Startup integration tests confirm `golang-migrate` owns `schema_migrations` after the bridge.
+
+---
+
+## Phase 3: Remove the Bridge
+
+Phase 3 is the cleanup release after phase 2 has shipped and the migration window has closed. The application should no longer carry any compatibility path for `public`.
+
+### Requirements
+
+- Remove the one-time schema bridge and any temporary startup logic that only exists for migration.
+- Keep `golang-migrate` as the only migration mechanism.
+- Keep the application operating solely against the `expensor` schema.
+- Leave the permanent migration setup minimal and easy to understand.
+
+### Validation
+
+- No phase-2 bridge code remains in the runtime path.
+- Startup still applies `golang-migrate` migrations and uses `schema_migrations`.
+- Existing tests cover normal startup and schema ownership without the bridge.
+
+---
+
+## Risks and Constraints
+
+- This is a multi-release migration program, not a single code change.
+- The phase-1 rename must land before any `golang-migrate` work that expects to own `schema_migrations`.
+- The phase-2 bridge must be deliberately one-time and removable; it must not become a permanent compatibility layer.
+- The schema move should be staged so existing data survives the transition without manual database resets.
+
+## Out of Scope
+
+- No schema cleanup inside unrelated feature work.
+- No permanent dual-write or shadow-read layer.
+- No direct migration to a custom `golang-migrate` table name unless a future decision explicitly requires it.


### PR DESCRIPTION
## Description

Rename the custom migration bookkeeping table to `legacy_schema_migrations` so the canonical `schema_migrations` name is reserved for the later `golang-migrate` release. This keeps the current sequential runner working for existing databases while establishing the phase-1 boundary for the migration rewrite.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Build/CI configuration change

## Related Issue

Fixes #(issue)

## Changes Made

- Renamed the custom migration runner bookkeeping table from `schema_migrations` to `legacy_schema_migrations`.
- Updated the migration bootstrap comment in `backend/migrations/001_init.sql` to match the new tracking table name.
- Added a migration-package integration test that verifies the renamed table is created and populated.
- Added a writer bootstrap integration test that verifies the legacy table name is present and the old name is absent.

## Testing

- [x] Unit tests pass (`task test:be`)
- [x] Linter passes (`task lint:be:prod` and `task lint:fe`)
- [ ] Manual testing completed
- [x] Added new tests (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This is phase 1 of a multi-PR migration plan. Phase 2 will adopt `golang-migrate` after the legacy table name has been freed.
